### PR TITLE
Renovate: Allow only semver versions smaller than 1000

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,14 @@
       "description": "Automerge non-major updates",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "matchPackagePrefixes": ["com.atlassian"],
+      "allowedVersions": "<1000"
+    },
+    {
+      "matchPackagePrefixes": ["com.atlassian"],
+      "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+$/"
     }
   ]
 }


### PR DESCRIPTION
With this change, renovate should not consider these weird 1000er versions or pre-release versions for QA anymore.