### PR TITLE
Make REST API method names more consistent

### DIFF
--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceImpl.java
@@ -44,7 +44,7 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
     }
 
     @Override
-    public Response setApplicationLink(
+    public Response updateApplicationLink(
             final UUID uuid,
             final boolean ignoreSetupErrors,
             final ApplicationLinkBean linkBean) {
@@ -55,7 +55,7 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
     }
 
     @Override
-    public Response addApplicationLink(
+    public Response createApplicationLink(
             final boolean ignoreSetupErrors,
             final ApplicationLinkBean linkBean) {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoriesResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoriesResourceImpl.java
@@ -38,7 +38,7 @@ public abstract class AbstractDirectoriesResourceImpl implements DirectoriesReso
     }
 
     @Override
-    public Response setDirectory (
+    public Response updateDirectory(
             final long id,
             final boolean testConnection,
             final AbstractDirectoryBean directory) {
@@ -48,7 +48,7 @@ public abstract class AbstractDirectoriesResourceImpl implements DirectoriesReso
     }
 
     @Override
-    public Response addDirectory (
+    public Response createDirectory(
             final boolean testConnection,
             final AbstractDirectoryBean directory) {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractGadgetsResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractGadgetsResourceImpl.java
@@ -36,7 +36,7 @@ public abstract class AbstractGadgetsResourceImpl implements GadgetsResource {
     }
 
     @Override
-    public Response setGadget(
+    public Response updateGadget(
             final long id,
             final GadgetBean gadgetBean) {
         GadgetBean updatedGadgetBean = gadgetsService.setGadget(
@@ -46,7 +46,7 @@ public abstract class AbstractGadgetsResourceImpl implements GadgetsResource {
     }
 
     @Override
-    public Response addGadget(
+    public Response createGadget(
             final GadgetBean gadgetBean) {
         GadgetBean addedGadgetBean = gadgetsService.addGadget(gadgetBean);
         return Response.ok(addedGadgetBean).build();

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
@@ -62,7 +62,7 @@ public interface ApplicationLinksResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { BootstrAPI.APPLICATION_LINKS },
-            summary = "Set or update a list of application links",
+            summary = "Set a list of application links",
             description = "NOTE: All existing application links with the same 'rpcUrl' attribute are updated.",
             responses = {
                     @ApiResponse(
@@ -78,6 +78,27 @@ public interface ApplicationLinksResource {
     Response setApplicationLinks(
             @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
             @NotNull final List<ApplicationLinkBean> applicationLinkBeans);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            tags = { BootstrAPI.APPLICATION_LINKS },
+            summary = "Create an application link",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class)),
+                            description = "Returns the added application link."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
+            }
+    )
+    Response createApplicationLink(
+            @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
+            @NotNull final ApplicationLinkBean linkBean);
 
     @PUT
     @Path("{uuid}")
@@ -97,31 +118,10 @@ public interface ApplicationLinksResource {
                     ),
             }
     )
-    Response setApplicationLink(
+    Response updateApplicationLink(
             @PathParam("uuid") @NotNull final UUID uuid,
             @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
             @NotNull final ApplicationLinkBean linksBeanBeans);
-
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { BootstrAPI.APPLICATION_LINKS },
-            summary = "Add an application link",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationLinkBean.class)),
-                            description = "Returns the added application link."
-                    ),
-                    @ApiResponse(
-                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
-                            description = "Returns a list of error messages."
-                    ),
-            }
-    )
-    Response addApplicationLink(
-            @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
-            @NotNull final ApplicationLinkBean linkBean);
 
     @DELETE
     @Operation(

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
@@ -60,7 +60,7 @@ public interface DirectoriesResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { BootstrAPI.DIRECTORIES },
-            summary = "Set or update a list of user directories",
+            summary = "Set a list of user directories",
             description = "NOTE: All existing directories with the same 'name' attribute are updated.",
             responses = {
                     @ApiResponse(
@@ -76,6 +76,27 @@ public interface DirectoriesResource {
     Response setDirectories(
             @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
             @NotNull final List<AbstractDirectoryBean> directories);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            tags = { BootstrAPI.DIRECTORIES },
+            summary = "Add a user directory",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class)),
+                            description = "Returns the added directory."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
+            }
+    )
+    Response createDirectory(
+            @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
+            @NotNull final AbstractDirectoryBean directory);
 
     @PUT
     @Path("{id}")
@@ -95,29 +116,8 @@ public interface DirectoriesResource {
                     ),
             }
     )
-    Response setDirectory(
+    Response updateDirectory(
             @PathParam("id") final long id,
-            @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
-            @NotNull final AbstractDirectoryBean directory);
-
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { BootstrAPI.DIRECTORIES },
-            summary = "Add a user directory",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200", content = @Content(schema = @Schema(implementation = AbstractDirectoryBean.class)),
-                            description = "Returns the added directory."
-                    ),
-                    @ApiResponse(
-                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
-                            description = "Returns a list of error messages."
-                    ),
-            }
-    )
-    Response addDirectory(
             @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
             @NotNull final AbstractDirectoryBean directory);
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/GadgetsResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/GadgetsResource.java
@@ -60,7 +60,7 @@ public interface GadgetsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { BootstrAPI.GADGETS },
-            summary = "Set or update a list of gadgets",
+            summary = "Set a list of gadgets",
             description = "NOTE: This will only create gadgets that does not exist yet as there is no real 'update'.",
             responses = {
                     @ApiResponse(
@@ -75,28 +75,6 @@ public interface GadgetsResource {
     )
     Response setGadgets(
             @NotNull final List<GadgetBean> gadgetBeans);
-
-    @PUT
-    @Path("{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { BootstrAPI.GADGETS },
-            summary = "Update a gadget",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class)),
-                            description = "Returns the updated gadget."
-                    ),
-                    @ApiResponse(
-                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
-                            description = "Returns a list of error messages."
-                    ),
-            }
-    )
-    Response setGadget(
-            @PathParam("id") final long id,
-            @NotNull final GadgetBean gadgetBean);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -116,7 +94,29 @@ public interface GadgetsResource {
                     ),
             }
     )
-    Response addGadget(
+    Response createGadget(
+            @NotNull final GadgetBean gadgetBean);
+
+    @PUT
+    @Path("{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            tags = { BootstrAPI.GADGETS },
+            summary = "Update a gadget",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = GadgetBean.class)),
+                            description = "Returns the updated gadget."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
+            }
+    )
+    Response updateGadget(
+            @PathParam("id") final long id,
             @NotNull final GadgetBean gadgetBean);
 
     @DELETE

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/ApplicationLinksResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/ApplicationLinksResourceTest.java
@@ -77,7 +77,7 @@ class ApplicationLinksResourceTest {
 
         doReturn(bean).when(applicationLinksService).setApplicationLink(id, bean, true);
 
-        final Response response = resource.setApplicationLink(id, true, bean);
+        final Response response = resource.updateApplicationLink(id, true, bean);
         assertEquals(200, response.getStatus());
         final ApplicationLinkBean linkBean = (ApplicationLinkBean) response.getEntity();
 
@@ -90,7 +90,7 @@ class ApplicationLinksResourceTest {
 
         doReturn(bean).when(applicationLinksService).addApplicationLink(bean, true);
 
-        final Response response = resource.addApplicationLink(true, bean);
+        final Response response = resource.createApplicationLink(true, bean);
         assertEquals(200, response.getStatus());
         final ApplicationLinkBean responseBean = (ApplicationLinkBean) response.getEntity();
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/DirectoriesResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/DirectoriesResourceTest.java
@@ -78,7 +78,7 @@ class DirectoriesResourceTest {
 
         doReturn(directoryBean).when(directoriesService).setDirectory(1L, directoryBean, false);
 
-        final Response response = resource.setDirectory(1L, Boolean.FALSE, directoryBean);
+        final Response response = resource.updateDirectory(1L, Boolean.FALSE, directoryBean);
         assertEquals(200, response.getStatus());
         final AbstractDirectoryBean directoryBeanResponse = (AbstractDirectoryBean) response.getEntity();
 
@@ -91,7 +91,7 @@ class DirectoriesResourceTest {
 
         doReturn(bean).when(directoriesService).addDirectory(bean, false);
 
-        final Response response = resource.addDirectory(Boolean.FALSE, bean);
+        final Response response = resource.createDirectory(Boolean.FALSE, bean);
         assertEquals(200, response.getStatus());
         final AbstractDirectoryBean responseBean = (AbstractDirectoryBean) response.getEntity();
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/GadgetsResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/GadgetsResourceTest.java
@@ -72,7 +72,7 @@ class GadgetsResourceTest {
         final GadgetBean bean = GadgetBean.EXAMPLE_1;
         doReturn(bean).when(gadgetsService).setGadget(1L, bean);
 
-        final Response response = resource.setGadget(1L, bean);
+        final Response response = resource.updateGadget(1L, bean);
         assertEquals(200, response.getStatus());
 
         final GadgetBean gadgetBean = (GadgetBean) response.getEntity();
@@ -84,7 +84,7 @@ class GadgetsResourceTest {
         final GadgetBean bean = GadgetBean.EXAMPLE_1;
         doReturn(bean).when(gadgetsService).addGadget(bean);
 
-        final Response response = resource.addGadget(bean);
+        final Response response = resource.createGadget(bean);
         assertEquals(200, response.getStatus());
 
         final GadgetBean responseBean = (GadgetBean) response.getEntity();

--- a/confluence/Apis/ApplicationLinksApi.md
+++ b/confluence/Apis/ApplicationLinksApi.md
@@ -4,20 +4,20 @@ All URIs are relative to *https://&lt;CONFLUENCE_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addApplicationLink**](ApplicationLinksApi.md#addApplicationLink) | **POST** /application-links | Add an application link |
+| [**createApplicationLink**](ApplicationLinksApi.md#createApplicationLink) | **POST** /application-links | Create an application link |
 | [**deleteApplicationLink**](ApplicationLinksApi.md#deleteApplicationLink) | **DELETE** /application-links/{uuid} | Delete an application link |
 | [**deleteApplicationLinks**](ApplicationLinksApi.md#deleteApplicationLinks) | **DELETE** /application-links | Delete all application links |
 | [**getApplicationLink**](ApplicationLinksApi.md#getApplicationLink) | **GET** /application-links/{uuid} | Get an application link |
 | [**getApplicationLinks**](ApplicationLinksApi.md#getApplicationLinks) | **GET** /application-links | Get all application links |
-| [**setApplicationLink**](ApplicationLinksApi.md#setApplicationLink) | **PUT** /application-links/{uuid} | Update an application link |
-| [**setApplicationLinks**](ApplicationLinksApi.md#setApplicationLinks) | **PUT** /application-links | Set or update a list of application links |
+| [**setApplicationLinks**](ApplicationLinksApi.md#setApplicationLinks) | **PUT** /application-links | Set a list of application links |
+| [**updateApplicationLink**](ApplicationLinksApi.md#updateApplicationLink) | **PUT** /application-links/{uuid} | Update an application link |
 
 
-<a name="addApplicationLink"></a>
-# **addApplicationLink**
-> ApplicationLinkBean addApplicationLink(ApplicationLinkBean, ignore-setup-errors)
+<a name="createApplicationLink"></a>
+# **createApplicationLink**
+> ApplicationLinkBean createApplicationLink(ApplicationLinkBean, ignore-setup-errors)
 
-Add an application link
+Create an application link
 
 ### Parameters
 
@@ -140,9 +140,37 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
-<a name="setApplicationLink"></a>
-# **setApplicationLink**
-> ApplicationLinkBean setApplicationLink(uuid, ApplicationLinkBean, ignore-setup-errors)
+<a name="setApplicationLinks"></a>
+# **setApplicationLinks**
+> List setApplicationLinks(ApplicationLinkBean, ignore-setup-errors)
+
+Set a list of application links
+
+    NOTE: All existing application links with the same &#39;rpcUrl&#39; attribute are updated.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **ApplicationLinkBean** | [**List**](../Models/ApplicationLinkBean.md)|  | |
+| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
+
+### Return type
+
+[**List**](../Models/ApplicationLinkBean.md)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="updateApplicationLink"></a>
+# **updateApplicationLink**
+> ApplicationLinkBean updateApplicationLink(uuid, ApplicationLinkBean, ignore-setup-errors)
 
 Update an application link
 
@@ -157,34 +185,6 @@ Update an application link
 ### Return type
 
 [**ApplicationLinkBean**](../Models/ApplicationLinkBean.md)
-
-### Authorization
-
-[basicAuth](../README.md#basicAuth)
-
-### HTTP request headers
-
-- **Content-Type**: application/json
-- **Accept**: application/json
-
-<a name="setApplicationLinks"></a>
-# **setApplicationLinks**
-> List setApplicationLinks(ApplicationLinkBean, ignore-setup-errors)
-
-Set or update a list of application links
-
-    NOTE: All existing application links with the same &#39;rpcUrl&#39; attribute are updated.
-
-### Parameters
-
-|Name | Type | Description  | Notes |
-|------------- | ------------- | ------------- | -------------|
-| **ApplicationLinkBean** | [**List**](../Models/ApplicationLinkBean.md)|  | |
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
-
-### Return type
-
-[**List**](../Models/ApplicationLinkBean.md)
 
 ### Authorization
 

--- a/confluence/Apis/DirectoriesApi.md
+++ b/confluence/Apis/DirectoriesApi.md
@@ -4,18 +4,18 @@ All URIs are relative to *https://&lt;CONFLUENCE_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addDirectory**](DirectoriesApi.md#addDirectory) | **POST** /directories | Add a user directory |
+| [**createDirectory**](DirectoriesApi.md#createDirectory) | **POST** /directories | Add a user directory |
 | [**deleteDirectories**](DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 | [**deleteDirectory**](DirectoriesApi.md#deleteDirectory) | **DELETE** /directories/{id} | Delete a user directory |
 | [**getDirectories**](DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
 | [**getDirectory**](DirectoriesApi.md#getDirectory) | **GET** /directories/{id} | Get a user directory |
-| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set or update a list of user directories |
-| [**setDirectory**](DirectoriesApi.md#setDirectory) | **PUT** /directories/{id} | Update a user directory |
+| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+| [**updateDirectory**](DirectoriesApi.md#updateDirectory) | **PUT** /directories/{id} | Update a user directory |
 
 
-<a name="addDirectory"></a>
-# **addDirectory**
-> AbstractDirectoryBean addDirectory(AbstractDirectoryBean, test-connection)
+<a name="createDirectory"></a>
+# **createDirectory**
+> AbstractDirectoryBean createDirectory(AbstractDirectoryBean, test-connection)
 
 Add a user directory
 
@@ -142,7 +142,7 @@ Get a user directory
 # **setDirectories**
 > List setDirectories(AbstractDirectoryBean, test-connection)
 
-Set or update a list of user directories
+Set a list of user directories
 
     NOTE: All existing directories with the same &#39;name&#39; attribute are updated.
 
@@ -166,9 +166,9 @@ Set or update a list of user directories
 - **Content-Type**: application/json
 - **Accept**: application/json
 
-<a name="setDirectory"></a>
-# **setDirectory**
-> AbstractDirectoryBean setDirectory(id, AbstractDirectoryBean, test-connection)
+<a name="updateDirectory"></a>
+# **updateDirectory**
+> AbstractDirectoryBean updateDirectory(id, AbstractDirectoryBean, test-connection)
 
 Update a user directory
 

--- a/confluence/Apis/GadgetsApi.md
+++ b/confluence/Apis/GadgetsApi.md
@@ -4,18 +4,18 @@ All URIs are relative to *https://&lt;CONFLUENCE_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addGadget**](GadgetsApi.md#addGadget) | **POST** /gadgets | Add a gadget |
+| [**createGadget**](GadgetsApi.md#createGadget) | **POST** /gadgets | Add a gadget |
 | [**deleteGadget**](GadgetsApi.md#deleteGadget) | **DELETE** /gadgets/{id} | Delete a gadget |
 | [**deleteGadgets**](GadgetsApi.md#deleteGadgets) | **DELETE** /gadgets | Delete all gadgets |
 | [**getGadget**](GadgetsApi.md#getGadget) | **GET** /gadgets/{id} | Get a gadget |
 | [**getGadgets**](GadgetsApi.md#getGadgets) | **GET** /gadgets | Get all gadgets |
-| [**setGadget**](GadgetsApi.md#setGadget) | **PUT** /gadgets/{id} | Update a gadget |
-| [**setGadgets**](GadgetsApi.md#setGadgets) | **PUT** /gadgets | Set or update a list of gadgets |
+| [**setGadgets**](GadgetsApi.md#setGadgets) | **PUT** /gadgets | Set a list of gadgets |
+| [**updateGadget**](GadgetsApi.md#updateGadget) | **PUT** /gadgets/{id} | Update a gadget |
 
 
-<a name="addGadget"></a>
-# **addGadget**
-> GadgetBean addGadget(GadgetBean)
+<a name="createGadget"></a>
+# **createGadget**
+> GadgetBean createGadget(GadgetBean)
 
 Add a gadget
 
@@ -139,9 +139,36 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
-<a name="setGadget"></a>
-# **setGadget**
-> GadgetBean setGadget(id, GadgetBean)
+<a name="setGadgets"></a>
+# **setGadgets**
+> List setGadgets(GadgetBean)
+
+Set a list of gadgets
+
+    NOTE: This will only create gadgets that does not exist yet as there is no real &#39;update&#39;.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **GadgetBean** | [**List**](../Models/GadgetBean.md)|  | |
+
+### Return type
+
+[**List**](../Models/GadgetBean.md)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="updateGadget"></a>
+# **updateGadget**
+> GadgetBean updateGadget(id, GadgetBean)
 
 Update a gadget
 
@@ -155,33 +182,6 @@ Update a gadget
 ### Return type
 
 [**GadgetBean**](../Models/GadgetBean.md)
-
-### Authorization
-
-[basicAuth](../README.md#basicAuth)
-
-### HTTP request headers
-
-- **Content-Type**: application/json
-- **Accept**: application/json
-
-<a name="setGadgets"></a>
-# **setGadgets**
-> List setGadgets(GadgetBean)
-
-Set or update a list of gadgets
-
-    NOTE: This will only create gadgets that does not exist yet as there is no real &#39;update&#39;.
-
-### Parameters
-
-|Name | Type | Description  | Notes |
-|------------- | ------------- | ------------- | -------------|
-| **GadgetBean** | [**List**](../Models/GadgetBean.md)|  | |
-
-### Return type
-
-[**List**](../Models/GadgetBean.md)
 
 ### Authorization
 

--- a/confluence/README.md
+++ b/confluence/README.md
@@ -7,13 +7,13 @@ All URIs are relative to *https://<CONFLUENCE_URL>/rest/bootstrapi/1*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|
-| *ApplicationLinksApi* | [**addApplicationLink**](Apis/ApplicationLinksApi.md#addapplicationlink) | **POST** /application-links | Add an application link |
+| *ApplicationLinksApi* | [**createApplicationLink**](Apis/ApplicationLinksApi.md#createapplicationlink) | **POST** /application-links | Create an application link |
 *ApplicationLinksApi* | [**deleteApplicationLink**](Apis/ApplicationLinksApi.md#deleteapplicationlink) | **DELETE** /application-links/{uuid} | Delete an application link |
 *ApplicationLinksApi* | [**deleteApplicationLinks**](Apis/ApplicationLinksApi.md#deleteapplicationlinks) | **DELETE** /application-links | Delete all application links |
 *ApplicationLinksApi* | [**getApplicationLink**](Apis/ApplicationLinksApi.md#getapplicationlink) | **GET** /application-links/{uuid} | Get an application link |
 *ApplicationLinksApi* | [**getApplicationLinks**](Apis/ApplicationLinksApi.md#getapplicationlinks) | **GET** /application-links | Get all application links |
-*ApplicationLinksApi* | [**setApplicationLink**](Apis/ApplicationLinksApi.md#setapplicationlink) | **PUT** /application-links/{uuid} | Update an application link |
-*ApplicationLinksApi* | [**setApplicationLinks**](Apis/ApplicationLinksApi.md#setapplicationlinks) | **PUT** /application-links | Set or update a list of application links |
+*ApplicationLinksApi* | [**setApplicationLinks**](Apis/ApplicationLinksApi.md#setapplicationlinks) | **PUT** /application-links | Set a list of application links |
+*ApplicationLinksApi* | [**updateApplicationLink**](Apis/ApplicationLinksApi.md#updateapplicationlink) | **PUT** /application-links/{uuid} | Update an application link |
 | *AuthenticationApi* | [**getAuthenticationIdps**](Apis/AuthenticationApi.md#getauthenticationidps) | **GET** /authentication/idps | Get all authentication identity providers |
 *AuthenticationApi* | [**getAuthenticationSso**](Apis/AuthenticationApi.md#getauthenticationsso) | **GET** /authentication/sso | Get authentication SSO configuration |
 *AuthenticationApi* | [**setAuthenticationIdps**](Apis/AuthenticationApi.md#setauthenticationidps) | **PATCH** /authentication/idps | Set all authentication identity providers |
@@ -22,20 +22,20 @@ All URIs are relative to *https://<CONFLUENCE_URL>/rest/bootstrapi/1*
 *CacheApi* | [**getCache**](Apis/CacheApi.md#getcache) | **GET** /caches/{name} | Read cache information for a specified cache |
 *CacheApi* | [**getCaches**](Apis/CacheApi.md#getcaches) | **GET** /caches | Read all cache information |
 *CacheApi* | [**updateCache**](Apis/CacheApi.md#updatecache) | **PUT** /caches/{name} | Update an existing cache-size. Only Setting maxObjectCount is supported. |
-| *DirectoriesApi* | [**addDirectory**](Apis/DirectoriesApi.md#adddirectory) | **POST** /directories | Add a user directory |
+| *DirectoriesApi* | [**createDirectory**](Apis/DirectoriesApi.md#createdirectory) | **POST** /directories | Add a user directory |
 *DirectoriesApi* | [**deleteDirectories**](Apis/DirectoriesApi.md#deletedirectories) | **DELETE** /directories | Delete all user directories |
 *DirectoriesApi* | [**deleteDirectory**](Apis/DirectoriesApi.md#deletedirectory) | **DELETE** /directories/{id} | Delete a user directory |
 *DirectoriesApi* | [**getDirectories**](Apis/DirectoriesApi.md#getdirectories) | **GET** /directories | Get all user directories |
 *DirectoriesApi* | [**getDirectory**](Apis/DirectoriesApi.md#getdirectory) | **GET** /directories/{id} | Get a user directory |
-*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setdirectories) | **PUT** /directories | Set or update a list of user directories |
-*DirectoriesApi* | [**setDirectory**](Apis/DirectoriesApi.md#setdirectory) | **PUT** /directories/{id} | Update a user directory |
-| *GadgetsApi* | [**addGadget**](Apis/GadgetsApi.md#addgadget) | **POST** /gadgets | Add a gadget |
+*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setdirectories) | **PUT** /directories | Set a list of user directories |
+*DirectoriesApi* | [**updateDirectory**](Apis/DirectoriesApi.md#updatedirectory) | **PUT** /directories/{id} | Update a user directory |
+| *GadgetsApi* | [**createGadget**](Apis/GadgetsApi.md#creategadget) | **POST** /gadgets | Add a gadget |
 *GadgetsApi* | [**deleteGadget**](Apis/GadgetsApi.md#deletegadget) | **DELETE** /gadgets/{id} | Delete a gadget |
 *GadgetsApi* | [**deleteGadgets**](Apis/GadgetsApi.md#deletegadgets) | **DELETE** /gadgets | Delete all gadgets |
 *GadgetsApi* | [**getGadget**](Apis/GadgetsApi.md#getgadget) | **GET** /gadgets/{id} | Get a gadget |
 *GadgetsApi* | [**getGadgets**](Apis/GadgetsApi.md#getgadgets) | **GET** /gadgets | Get all gadgets |
-*GadgetsApi* | [**setGadget**](Apis/GadgetsApi.md#setgadget) | **PUT** /gadgets/{id} | Update a gadget |
-*GadgetsApi* | [**setGadgets**](Apis/GadgetsApi.md#setgadgets) | **PUT** /gadgets | Set or update a list of gadgets |
+*GadgetsApi* | [**setGadgets**](Apis/GadgetsApi.md#setgadgets) | **PUT** /gadgets | Set a list of gadgets |
+*GadgetsApi* | [**updateGadget**](Apis/GadgetsApi.md#updategadget) | **PUT** /gadgets/{id} | Update a gadget |
 | *LicensesApi* | [**addLicense**](Apis/LicensesApi.md#addlicense) | **POST** /licenses | Add a license |
 *LicensesApi* | [**getLicenses**](Apis/LicensesApi.md#getlicenses) | **GET** /licenses | Get all licenses information |
 | *MailServerApi* | [**getMailServerPop**](Apis/MailServerApi.md#getmailserverpop) | **GET** /mail-server/pop | Get the default POP mail server |

--- a/crowd/Apis/ApplicationLinksApi.md
+++ b/crowd/Apis/ApplicationLinksApi.md
@@ -4,20 +4,20 @@ All URIs are relative to *https://&lt;CROWD_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addApplicationLink**](ApplicationLinksApi.md#addApplicationLink) | **POST** /application-links | Add an application link |
+| [**createApplicationLink**](ApplicationLinksApi.md#createApplicationLink) | **POST** /application-links | Create an application link |
 | [**deleteApplicationLink**](ApplicationLinksApi.md#deleteApplicationLink) | **DELETE** /application-links/{uuid} | Delete an application link |
 | [**deleteApplicationLinks**](ApplicationLinksApi.md#deleteApplicationLinks) | **DELETE** /application-links | Delete all application links |
 | [**getApplicationLink**](ApplicationLinksApi.md#getApplicationLink) | **GET** /application-links/{uuid} | Get an application link |
 | [**getApplicationLinks**](ApplicationLinksApi.md#getApplicationLinks) | **GET** /application-links | Get all application links |
-| [**setApplicationLink**](ApplicationLinksApi.md#setApplicationLink) | **PUT** /application-links/{uuid} | Update an application link |
-| [**setApplicationLinks**](ApplicationLinksApi.md#setApplicationLinks) | **PUT** /application-links | Set or update a list of application links |
+| [**setApplicationLinks**](ApplicationLinksApi.md#setApplicationLinks) | **PUT** /application-links | Set a list of application links |
+| [**updateApplicationLink**](ApplicationLinksApi.md#updateApplicationLink) | **PUT** /application-links/{uuid} | Update an application link |
 
 
-<a name="addApplicationLink"></a>
-# **addApplicationLink**
-> ApplicationLinkBean addApplicationLink(ApplicationLinkBean, ignore-setup-errors)
+<a name="createApplicationLink"></a>
+# **createApplicationLink**
+> ApplicationLinkBean createApplicationLink(ApplicationLinkBean, ignore-setup-errors)
 
-Add an application link
+Create an application link
 
 ### Parameters
 
@@ -140,9 +140,37 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
-<a name="setApplicationLink"></a>
-# **setApplicationLink**
-> ApplicationLinkBean setApplicationLink(uuid, ApplicationLinkBean, ignore-setup-errors)
+<a name="setApplicationLinks"></a>
+# **setApplicationLinks**
+> List setApplicationLinks(ApplicationLinkBean, ignore-setup-errors)
+
+Set a list of application links
+
+    NOTE: All existing application links with the same &#39;rpcUrl&#39; attribute are updated.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **ApplicationLinkBean** | [**List**](../Models/ApplicationLinkBean.md)|  | |
+| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
+
+### Return type
+
+[**List**](../Models/ApplicationLinkBean.md)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="updateApplicationLink"></a>
+# **updateApplicationLink**
+> ApplicationLinkBean updateApplicationLink(uuid, ApplicationLinkBean, ignore-setup-errors)
 
 Update an application link
 
@@ -157,34 +185,6 @@ Update an application link
 ### Return type
 
 [**ApplicationLinkBean**](../Models/ApplicationLinkBean.md)
-
-### Authorization
-
-[basicAuth](../README.md#basicAuth)
-
-### HTTP request headers
-
-- **Content-Type**: application/json
-- **Accept**: application/json
-
-<a name="setApplicationLinks"></a>
-# **setApplicationLinks**
-> List setApplicationLinks(ApplicationLinkBean, ignore-setup-errors)
-
-Set or update a list of application links
-
-    NOTE: All existing application links with the same &#39;rpcUrl&#39; attribute are updated.
-
-### Parameters
-
-|Name | Type | Description  | Notes |
-|------------- | ------------- | ------------- | -------------|
-| **ApplicationLinkBean** | [**List**](../Models/ApplicationLinkBean.md)|  | |
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
-
-### Return type
-
-[**List**](../Models/ApplicationLinkBean.md)
 
 ### Authorization
 

--- a/crowd/Apis/ApplicationsApi.md
+++ b/crowd/Apis/ApplicationsApi.md
@@ -4,18 +4,18 @@ All URIs are relative to *https://&lt;CROWD_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addApplication**](ApplicationsApi.md#addApplication) | **POST** /applications | Add an application |
+| [**createApplication**](ApplicationsApi.md#createApplication) | **POST** /applications | Add an application |
 | [**deleteApplication**](ApplicationsApi.md#deleteApplication) | **DELETE** /applications/{id} | Delete an application |
 | [**deleteApplications**](ApplicationsApi.md#deleteApplications) | **DELETE** /applications | Delete all applications |
 | [**getApplication**](ApplicationsApi.md#getApplication) | **GET** /applications/{id} | Get an application |
 | [**getApplications**](ApplicationsApi.md#getApplications) | **GET** /applications | Get all applications |
-| [**setApplication**](ApplicationsApi.md#setApplication) | **PUT** /applications/{id} | Update an application |
-| [**setApplications**](ApplicationsApi.md#setApplications) | **PUT** /applications | Set or update a list of applications |
+| [**setApplications**](ApplicationsApi.md#setApplications) | **PUT** /applications | Set a list of applications |
+| [**updateApplication**](ApplicationsApi.md#updateApplication) | **PUT** /applications/{id} | Update an application |
 
 
-<a name="addApplication"></a>
-# **addApplication**
-> ApplicationBean addApplication(ApplicationBean)
+<a name="createApplication"></a>
+# **createApplication**
+> ApplicationBean createApplication(ApplicationBean)
 
 Add an application
 
@@ -139,9 +139,36 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
-<a name="setApplication"></a>
-# **setApplication**
-> ApplicationBean setApplication(id, ApplicationBean)
+<a name="setApplications"></a>
+# **setApplications**
+> List setApplications(ApplicationBean)
+
+Set a list of applications
+
+    NOTE: All existing applications with the same &#39;name&#39; attribute are updated.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **ApplicationBean** | [**List**](../Models/ApplicationBean.md)|  | [optional] |
+
+### Return type
+
+[**List**](../Models/ApplicationBean.md)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="updateApplication"></a>
+# **updateApplication**
+> ApplicationBean updateApplication(id, ApplicationBean)
 
 Update an application
 
@@ -155,33 +182,6 @@ Update an application
 ### Return type
 
 [**ApplicationBean**](../Models/ApplicationBean.md)
-
-### Authorization
-
-[basicAuth](../README.md#basicAuth)
-
-### HTTP request headers
-
-- **Content-Type**: application/json
-- **Accept**: application/json
-
-<a name="setApplications"></a>
-# **setApplications**
-> List setApplications(ApplicationBean)
-
-Set or update a list of applications
-
-    NOTE: All existing applications with the same &#39;name&#39; attribute are updated.
-
-### Parameters
-
-|Name | Type | Description  | Notes |
-|------------- | ------------- | ------------- | -------------|
-| **ApplicationBean** | [**List**](../Models/ApplicationBean.md)|  | [optional] |
-
-### Return type
-
-[**List**](../Models/ApplicationBean.md)
 
 ### Authorization
 

--- a/crowd/Apis/DirectoriesApi.md
+++ b/crowd/Apis/DirectoriesApi.md
@@ -4,18 +4,18 @@ All URIs are relative to *https://&lt;CROWD_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addDirectory**](DirectoriesApi.md#addDirectory) | **POST** /directories | Add a user directory |
+| [**createDirectory**](DirectoriesApi.md#createDirectory) | **POST** /directories | Add a user directory |
 | [**deleteDirectories**](DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 | [**deleteDirectory**](DirectoriesApi.md#deleteDirectory) | **DELETE** /directories/{id} | Delete a user directory |
 | [**getDirectories**](DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
 | [**getDirectory**](DirectoriesApi.md#getDirectory) | **GET** /directories/{id} | Get a user directory |
-| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set or update a list of user directories |
-| [**setDirectory**](DirectoriesApi.md#setDirectory) | **PUT** /directories/{id} | Update a user directory |
+| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+| [**updateDirectory**](DirectoriesApi.md#updateDirectory) | **PUT** /directories/{id} | Update a user directory |
 
 
-<a name="addDirectory"></a>
-# **addDirectory**
-> AbstractDirectoryBean addDirectory(AbstractDirectoryBean, test-connection)
+<a name="createDirectory"></a>
+# **createDirectory**
+> AbstractDirectoryBean createDirectory(AbstractDirectoryBean, test-connection)
 
 Add a user directory
 
@@ -142,7 +142,7 @@ Get a user directory
 # **setDirectories**
 > List setDirectories(AbstractDirectoryBean, test-connection)
 
-Set or update a list of user directories
+Set a list of user directories
 
     NOTE: All existing directories with the same &#39;name&#39; attribute are updated.
 
@@ -166,9 +166,9 @@ Set or update a list of user directories
 - **Content-Type**: application/json
 - **Accept**: application/json
 
-<a name="setDirectory"></a>
-# **setDirectory**
-> AbstractDirectoryBean setDirectory(id, AbstractDirectoryBean, test-connection)
+<a name="updateDirectory"></a>
+# **updateDirectory**
+> AbstractDirectoryBean updateDirectory(id, AbstractDirectoryBean, test-connection)
 
 Update a user directory
 

--- a/crowd/README.md
+++ b/crowd/README.md
@@ -8,27 +8,27 @@ All URIs are relative to *https://<CROWD_URL>/rest/bootstrapi/1*
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|
 | *AllApi* | [**setAll**](Apis/AllApi.md#setall) | **PUT** / | Set the whole configuration |
-| *ApplicationLinksApi* | [**addApplicationLink**](Apis/ApplicationLinksApi.md#addapplicationlink) | **POST** /application-links | Add an application link |
+| *ApplicationLinksApi* | [**createApplicationLink**](Apis/ApplicationLinksApi.md#createapplicationlink) | **POST** /application-links | Create an application link |
 *ApplicationLinksApi* | [**deleteApplicationLink**](Apis/ApplicationLinksApi.md#deleteapplicationlink) | **DELETE** /application-links/{uuid} | Delete an application link |
 *ApplicationLinksApi* | [**deleteApplicationLinks**](Apis/ApplicationLinksApi.md#deleteapplicationlinks) | **DELETE** /application-links | Delete all application links |
 *ApplicationLinksApi* | [**getApplicationLink**](Apis/ApplicationLinksApi.md#getapplicationlink) | **GET** /application-links/{uuid} | Get an application link |
 *ApplicationLinksApi* | [**getApplicationLinks**](Apis/ApplicationLinksApi.md#getapplicationlinks) | **GET** /application-links | Get all application links |
-*ApplicationLinksApi* | [**setApplicationLink**](Apis/ApplicationLinksApi.md#setapplicationlink) | **PUT** /application-links/{uuid} | Update an application link |
-*ApplicationLinksApi* | [**setApplicationLinks**](Apis/ApplicationLinksApi.md#setapplicationlinks) | **PUT** /application-links | Set or update a list of application links |
-| *ApplicationsApi* | [**addApplication**](Apis/ApplicationsApi.md#addapplication) | **POST** /applications | Add an application |
+*ApplicationLinksApi* | [**setApplicationLinks**](Apis/ApplicationLinksApi.md#setapplicationlinks) | **PUT** /application-links | Set a list of application links |
+*ApplicationLinksApi* | [**updateApplicationLink**](Apis/ApplicationLinksApi.md#updateapplicationlink) | **PUT** /application-links/{uuid} | Update an application link |
+| *ApplicationsApi* | [**createApplication**](Apis/ApplicationsApi.md#createapplication) | **POST** /applications | Add an application |
 *ApplicationsApi* | [**deleteApplication**](Apis/ApplicationsApi.md#deleteapplication) | **DELETE** /applications/{id} | Delete an application |
 *ApplicationsApi* | [**deleteApplications**](Apis/ApplicationsApi.md#deleteapplications) | **DELETE** /applications | Delete all applications |
 *ApplicationsApi* | [**getApplication**](Apis/ApplicationsApi.md#getapplication) | **GET** /applications/{id} | Get an application |
 *ApplicationsApi* | [**getApplications**](Apis/ApplicationsApi.md#getapplications) | **GET** /applications | Get all applications |
-*ApplicationsApi* | [**setApplication**](Apis/ApplicationsApi.md#setapplication) | **PUT** /applications/{id} | Update an application |
-*ApplicationsApi* | [**setApplications**](Apis/ApplicationsApi.md#setapplications) | **PUT** /applications | Set or update a list of applications |
-| *DirectoriesApi* | [**addDirectory**](Apis/DirectoriesApi.md#adddirectory) | **POST** /directories | Add a user directory |
+*ApplicationsApi* | [**setApplications**](Apis/ApplicationsApi.md#setapplications) | **PUT** /applications | Set a list of applications |
+*ApplicationsApi* | [**updateApplication**](Apis/ApplicationsApi.md#updateapplication) | **PUT** /applications/{id} | Update an application |
+| *DirectoriesApi* | [**createDirectory**](Apis/DirectoriesApi.md#createdirectory) | **POST** /directories | Add a user directory |
 *DirectoriesApi* | [**deleteDirectories**](Apis/DirectoriesApi.md#deletedirectories) | **DELETE** /directories | Delete all user directories |
 *DirectoriesApi* | [**deleteDirectory**](Apis/DirectoriesApi.md#deletedirectory) | **DELETE** /directories/{id} | Delete a user directory |
 *DirectoriesApi* | [**getDirectories**](Apis/DirectoriesApi.md#getdirectories) | **GET** /directories | Get all user directories |
 *DirectoriesApi* | [**getDirectory**](Apis/DirectoriesApi.md#getdirectory) | **GET** /directories/{id} | Get a user directory |
-*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setdirectories) | **PUT** /directories | Set or update a list of user directories |
-*DirectoriesApi* | [**setDirectory**](Apis/DirectoriesApi.md#setdirectory) | **PUT** /directories/{id} | Update a user directory |
+*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setdirectories) | **PUT** /directories | Set a list of user directories |
+*DirectoriesApi* | [**updateDirectory**](Apis/DirectoriesApi.md#updatedirectory) | **PUT** /directories/{id} | Update a user directory |
 | *GroupsApi* | [**createGroup**](Apis/GroupsApi.md#creategroup) | **POST** /groups | Create a group |
 *GroupsApi* | [**getGroup**](Apis/GroupsApi.md#getgroup) | **GET** /groups | Get a group |
 *GroupsApi* | [**setGroups**](Apis/GroupsApi.md#setgroups) | **PATCH** /groups | Set groups |

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceImpl.java
@@ -44,14 +44,14 @@ public class ApplicationsResourceImpl implements ApplicationsResource {
     }
 
     @Override
-    public Response setApplication(
+    public Response updateApplication(
             final long id,
             final ApplicationBean applicationBean) {
         return Response.ok(applicationsService.setApplication(id, applicationBean)).build();
     }
 
     @Override
-    public Response addApplication(
+    public Response createApplication(
             final ApplicationBean applicationBean) {
         return Response.ok(applicationsService.addApplication(applicationBean)).build();
     }

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
@@ -61,7 +61,7 @@ public interface ApplicationsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { BootstrAPI.APPLICATIONS },
-            summary = "Set or update a list of applications",
+            summary = "Set a list of applications",
             description = "NOTE: All existing applications with the same 'name' attribute are updated.",
             responses = {
                     @ApiResponse(
@@ -76,6 +76,26 @@ public interface ApplicationsResource {
     )
     Response setApplications(
             List<ApplicationBean> applicationBeans);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            tags = { BootstrAPI.APPLICATIONS },
+            summary = "Add an application",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationBean.class)),
+                            description = "Returns the added application."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
+            }
+    )
+    Response createApplication(
+            ApplicationBean applicationBean);
 
     @PUT
     @Path("{id}")
@@ -95,29 +115,9 @@ public interface ApplicationsResource {
                     ),
             }
     )
-    Response setApplication(
+    Response updateApplication(
             @PathParam("id") long id,
             ApplicationBean applicationsBeanBeans);
-
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(
-            tags = { BootstrAPI.APPLICATIONS },
-            summary = "Add an application",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200", content = @Content(schema = @Schema(implementation = ApplicationBean.class)),
-                            description = "Returns the added application."
-                    ),
-                    @ApiResponse(
-                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
-                            description = "Returns a list of error messages."
-                    ),
-            }
-    )
-    Response addApplication(
-            ApplicationBean applicationBean);
 
     @DELETE
     @Operation(

--- a/jira/Apis/ApplicationLinksApi.md
+++ b/jira/Apis/ApplicationLinksApi.md
@@ -4,20 +4,20 @@ All URIs are relative to *https://&lt;JIRA_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addApplicationLink**](ApplicationLinksApi.md#addApplicationLink) | **POST** /application-links | Add an application link |
+| [**createApplicationLink**](ApplicationLinksApi.md#createApplicationLink) | **POST** /application-links | Create an application link |
 | [**deleteApplicationLink**](ApplicationLinksApi.md#deleteApplicationLink) | **DELETE** /application-links/{uuid} | Delete an application link |
 | [**deleteApplicationLinks**](ApplicationLinksApi.md#deleteApplicationLinks) | **DELETE** /application-links | Delete all application links |
 | [**getApplicationLink**](ApplicationLinksApi.md#getApplicationLink) | **GET** /application-links/{uuid} | Get an application link |
 | [**getApplicationLinks**](ApplicationLinksApi.md#getApplicationLinks) | **GET** /application-links | Get all application links |
-| [**setApplicationLink**](ApplicationLinksApi.md#setApplicationLink) | **PUT** /application-links/{uuid} | Update an application link |
-| [**setApplicationLinks**](ApplicationLinksApi.md#setApplicationLinks) | **PUT** /application-links | Set or update a list of application links |
+| [**setApplicationLinks**](ApplicationLinksApi.md#setApplicationLinks) | **PUT** /application-links | Set a list of application links |
+| [**updateApplicationLink**](ApplicationLinksApi.md#updateApplicationLink) | **PUT** /application-links/{uuid} | Update an application link |
 
 
-<a name="addApplicationLink"></a>
-# **addApplicationLink**
-> ApplicationLinkBean addApplicationLink(ApplicationLinkBean, ignore-setup-errors)
+<a name="createApplicationLink"></a>
+# **createApplicationLink**
+> ApplicationLinkBean createApplicationLink(ApplicationLinkBean, ignore-setup-errors)
 
-Add an application link
+Create an application link
 
 ### Parameters
 
@@ -140,9 +140,37 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
-<a name="setApplicationLink"></a>
-# **setApplicationLink**
-> ApplicationLinkBean setApplicationLink(uuid, ApplicationLinkBean, ignore-setup-errors)
+<a name="setApplicationLinks"></a>
+# **setApplicationLinks**
+> List setApplicationLinks(ApplicationLinkBean, ignore-setup-errors)
+
+Set a list of application links
+
+    NOTE: All existing application links with the same &#39;rpcUrl&#39; attribute are updated.
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **ApplicationLinkBean** | [**List**](../Models/ApplicationLinkBean.md)|  | |
+| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
+
+### Return type
+
+[**List**](../Models/ApplicationLinkBean.md)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+<a name="updateApplicationLink"></a>
+# **updateApplicationLink**
+> ApplicationLinkBean updateApplicationLink(uuid, ApplicationLinkBean, ignore-setup-errors)
 
 Update an application link
 
@@ -157,34 +185,6 @@ Update an application link
 ### Return type
 
 [**ApplicationLinkBean**](../Models/ApplicationLinkBean.md)
-
-### Authorization
-
-[basicAuth](../README.md#basicAuth)
-
-### HTTP request headers
-
-- **Content-Type**: application/json
-- **Accept**: application/json
-
-<a name="setApplicationLinks"></a>
-# **setApplicationLinks**
-> List setApplicationLinks(ApplicationLinkBean, ignore-setup-errors)
-
-Set or update a list of application links
-
-    NOTE: All existing application links with the same &#39;rpcUrl&#39; attribute are updated.
-
-### Parameters
-
-|Name | Type | Description  | Notes |
-|------------- | ------------- | ------------- | -------------|
-| **ApplicationLinkBean** | [**List**](../Models/ApplicationLinkBean.md)|  | |
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
-
-### Return type
-
-[**List**](../Models/ApplicationLinkBean.md)
 
 ### Authorization
 

--- a/jira/Apis/DirectoriesApi.md
+++ b/jira/Apis/DirectoriesApi.md
@@ -4,18 +4,18 @@ All URIs are relative to *https://&lt;JIRA_URL&gt;/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**addDirectory**](DirectoriesApi.md#addDirectory) | **POST** /directories | Add a user directory |
+| [**createDirectory**](DirectoriesApi.md#createDirectory) | **POST** /directories | Add a user directory |
 | [**deleteDirectories**](DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 | [**deleteDirectory**](DirectoriesApi.md#deleteDirectory) | **DELETE** /directories/{id} | Delete a user directory |
 | [**getDirectories**](DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
 | [**getDirectory**](DirectoriesApi.md#getDirectory) | **GET** /directories/{id} | Get a user directory |
-| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set or update a list of user directories |
-| [**setDirectory**](DirectoriesApi.md#setDirectory) | **PUT** /directories/{id} | Update a user directory |
+| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+| [**updateDirectory**](DirectoriesApi.md#updateDirectory) | **PUT** /directories/{id} | Update a user directory |
 
 
-<a name="addDirectory"></a>
-# **addDirectory**
-> AbstractDirectoryBean addDirectory(AbstractDirectoryBean, test-connection)
+<a name="createDirectory"></a>
+# **createDirectory**
+> AbstractDirectoryBean createDirectory(AbstractDirectoryBean, test-connection)
 
 Add a user directory
 
@@ -142,7 +142,7 @@ Get a user directory
 # **setDirectories**
 > List setDirectories(AbstractDirectoryBean, test-connection)
 
-Set or update a list of user directories
+Set a list of user directories
 
     NOTE: All existing directories with the same &#39;name&#39; attribute are updated.
 
@@ -166,9 +166,9 @@ Set or update a list of user directories
 - **Content-Type**: application/json
 - **Accept**: application/json
 
-<a name="setDirectory"></a>
-# **setDirectory**
-> AbstractDirectoryBean setDirectory(id, AbstractDirectoryBean, test-connection)
+<a name="updateDirectory"></a>
+# **updateDirectory**
+> AbstractDirectoryBean updateDirectory(id, AbstractDirectoryBean, test-connection)
 
 Update a user directory
 

--- a/jira/README.md
+++ b/jira/README.md
@@ -7,24 +7,24 @@ All URIs are relative to *https://<JIRA_URL>/rest/bootstrapi/1*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|
-| *ApplicationLinksApi* | [**addApplicationLink**](Apis/ApplicationLinksApi.md#addapplicationlink) | **POST** /application-links | Add an application link |
+| *ApplicationLinksApi* | [**createApplicationLink**](Apis/ApplicationLinksApi.md#createapplicationlink) | **POST** /application-links | Create an application link |
 *ApplicationLinksApi* | [**deleteApplicationLink**](Apis/ApplicationLinksApi.md#deleteapplicationlink) | **DELETE** /application-links/{uuid} | Delete an application link |
 *ApplicationLinksApi* | [**deleteApplicationLinks**](Apis/ApplicationLinksApi.md#deleteapplicationlinks) | **DELETE** /application-links | Delete all application links |
 *ApplicationLinksApi* | [**getApplicationLink**](Apis/ApplicationLinksApi.md#getapplicationlink) | **GET** /application-links/{uuid} | Get an application link |
 *ApplicationLinksApi* | [**getApplicationLinks**](Apis/ApplicationLinksApi.md#getapplicationlinks) | **GET** /application-links | Get all application links |
-*ApplicationLinksApi* | [**setApplicationLink**](Apis/ApplicationLinksApi.md#setapplicationlink) | **PUT** /application-links/{uuid} | Update an application link |
-*ApplicationLinksApi* | [**setApplicationLinks**](Apis/ApplicationLinksApi.md#setapplicationlinks) | **PUT** /application-links | Set or update a list of application links |
+*ApplicationLinksApi* | [**setApplicationLinks**](Apis/ApplicationLinksApi.md#setapplicationlinks) | **PUT** /application-links | Set a list of application links |
+*ApplicationLinksApi* | [**updateApplicationLink**](Apis/ApplicationLinksApi.md#updateapplicationlink) | **PUT** /application-links/{uuid} | Update an application link |
 | *AuthenticationApi* | [**getAuthenticationIdps**](Apis/AuthenticationApi.md#getauthenticationidps) | **GET** /authentication/idps | Get all authentication identity providers |
 *AuthenticationApi* | [**getAuthenticationSso**](Apis/AuthenticationApi.md#getauthenticationsso) | **GET** /authentication/sso | Get authentication SSO configuration |
 *AuthenticationApi* | [**setAuthenticationIdps**](Apis/AuthenticationApi.md#setauthenticationidps) | **PATCH** /authentication/idps | Set all authentication identity providers |
 *AuthenticationApi* | [**setAuthenticationSso**](Apis/AuthenticationApi.md#setauthenticationsso) | **PATCH** /authentication/sso | Set authentication SSO configuration |
-| *DirectoriesApi* | [**addDirectory**](Apis/DirectoriesApi.md#adddirectory) | **POST** /directories | Add a user directory |
+| *DirectoriesApi* | [**createDirectory**](Apis/DirectoriesApi.md#createdirectory) | **POST** /directories | Add a user directory |
 *DirectoriesApi* | [**deleteDirectories**](Apis/DirectoriesApi.md#deletedirectories) | **DELETE** /directories | Delete all user directories |
 *DirectoriesApi* | [**deleteDirectory**](Apis/DirectoriesApi.md#deletedirectory) | **DELETE** /directories/{id} | Delete a user directory |
 *DirectoriesApi* | [**getDirectories**](Apis/DirectoriesApi.md#getdirectories) | **GET** /directories | Get all user directories |
 *DirectoriesApi* | [**getDirectory**](Apis/DirectoriesApi.md#getdirectory) | **GET** /directories/{id} | Get a user directory |
-*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setdirectories) | **PUT** /directories | Set or update a list of user directories |
-*DirectoriesApi* | [**setDirectory**](Apis/DirectoriesApi.md#setdirectory) | **PUT** /directories/{id} | Update a user directory |
+*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setdirectories) | **PUT** /directories | Set a list of user directories |
+*DirectoriesApi* | [**updateDirectory**](Apis/DirectoriesApi.md#updatedirectory) | **PUT** /directories/{id} | Update a user directory |
 | *LicensesApi* | [**addLicense**](Apis/LicensesApi.md#addlicense) | **POST** /licenses | Add a license |
 *LicensesApi* | [**getLicenses**](Apis/LicensesApi.md#getlicenses) | **GET** /licenses | Get all licenses information |
 | *MailServerApi* | [**getMailServerPop**](Apis/MailServerApi.md#getmailserverpop) | **GET** /mail-server/pop | Get the default POP mail server |


### PR DESCRIPTION
In entity collections such as application links, where each entity itself is a complex construct already, we use the following naming scheme together with the following HTTP methods.

Single entity:

- `GET`:    getEntity
- `POST`:   createEntity
- `PUT`:    updateEntity
- `DELETE`: deleteEntity

Multiple entities:

- `GET`:    getEntities
- `PUT`:    setEntities
- `DELETE`: deleteEntities

Whereas `PUT` setEntities will be replaced by `PATCH` in a future release to better explain that these methods may create OR update entities, but only the ones that are sent in the request.

For collections that kind of form a single entity themselves, the methods work a bit different. E.g. the trusted proxies in Crowd are one single entity in the form of a list of entries (the trusted proxies). Here, and in similar cases, we would use:

- `GET`:    getEntries
- `PUT`:    setEntries
- `POST`:   addEntry
- `DELETE`: removeEntry

However, here we would stick to `PUT` for setEntries since it makes more sense.