### PR TITLE
Jira: Fix banner endpoint, support long strings

### DIFF
--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/SettingsServiceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/SettingsServiceImpl.java
@@ -99,7 +99,7 @@ public class SettingsServiceImpl implements JiraSettingsService {
             final SettingsBannerBean settingsBannerBean) {
 
         if (settingsBannerBean.getContent() != null) {
-            applicationProperties.setString(JIRA_ALERT_HEADER, settingsBannerBean.getContent());
+            applicationProperties.setText(JIRA_ALERT_HEADER, settingsBannerBean.getContent());
         }
 
         if (settingsBannerBean.getVisibility() != null) {

--- a/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/SettingsServiceTest.java
+++ b/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/SettingsServiceTest.java
@@ -128,7 +128,7 @@ class SettingsServiceTest {
         doReturn(settingsBannerBean).when(spy).getBanner();
 
         spy.setBanner(settingsBannerBean);
-        verify(applicationProperties).setString(JIRA_ALERT_HEADER, settingsBannerBean.getContent());
+        verify(applicationProperties).setText(JIRA_ALERT_HEADER, settingsBannerBean.getContent());
         verify(applicationProperties).setString(JIRA_ALERT_HEADER_VISIBILITY, settingsBannerBean.getVisibility().name().toLowerCase());
         verify(spy).getBanner();
     }


### PR DESCRIPTION
The initial implementation used the wrong method for setting application properties (set string vs. set text). This resulted in a bug that prevented setting banner contents longer than 255 characters. Now, the correct method is used so that the bug is fixed.