### PR TITLE
Fix dependency management orders in pom.xml files

### DIFF
--- a/confluence/pom.xml
+++ b/confluence/pom.xml
@@ -60,6 +60,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.deftdevs</groupId>
+                <artifactId>bootstrapi-parent</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>com.atlassian.confluence</groupId>
                 <artifactId>confluence-project</artifactId>
                 <version>${confluence.version}</version>
@@ -71,14 +79,6 @@
                 <groupId>com.atlassian.confluence</groupId>
                 <artifactId>confluence-plugins-platform-pom</artifactId>
                 <version>${confluence.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.deftdevs</groupId>
-                <artifactId>bootstrapi-parent</artifactId>
-                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/crowd/pom.xml
+++ b/crowd/pom.xml
@@ -58,17 +58,17 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.atlassian.crowd</groupId>
-                <artifactId>atlassian-crowd</artifactId>
-                <version>${crowd.version}</version>
+                <groupId>com.deftdevs</groupId>
+                <artifactId>bootstrapi-parent</artifactId>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
             <dependency>
-                <groupId>com.deftdevs</groupId>
-                <artifactId>bootstrapi-parent</artifactId>
-                <version>${project.version}</version>
+                <groupId>com.atlassian.crowd</groupId>
+                <artifactId>atlassian-crowd</artifactId>
+                <version>${crowd.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -50,6 +50,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.deftdevs</groupId>
+                <artifactId>bootstrapi-parent</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>com.atlassian.jira</groupId>
                 <artifactId>jira-api</artifactId>
                 <version>${jira.version}</version>
@@ -61,14 +69,6 @@
                 <groupId>com.atlassian.jira</groupId>
                 <artifactId>jira-plugins</artifactId>
                 <version>${jira.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.deftdevs</groupId>
-                <artifactId>bootstrapi-parent</artifactId>
-                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This ensures that our own dependencies are always prioritised.