### PR TITLE
Use map-based endpoints for bulk REST resources

### DIFF
--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryExternalModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryExternalModel.java
@@ -1,0 +1,21 @@
+package com.deftdevs.bootstrapi.commons.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import javax.xml.bind.annotation.XmlElement;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public abstract class AbstractDirectoryExternalModel extends AbstractDirectoryModel {
+
+    @XmlElement
+    private Boolean testConnection;
+
+}

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryModel.java
@@ -9,7 +9,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
@@ -48,7 +47,6 @@ public abstract class AbstractDirectoryModel {
     private Long id;
 
     @XmlElement
-    @NotNull
     private String name;
 
     @XmlElement

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/ApplicationLinkModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/ApplicationLinkModel.java
@@ -6,7 +6,6 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.net.URI;
@@ -47,19 +46,15 @@ public class ApplicationLinkModel {
     private UUID uuid;
 
     @XmlElement
-    @NotNull
     private String name;
 
     @XmlElement
-    @NotNull
     private ApplicationLinkType type;
 
     @XmlElement
-    @NotNull
     private URI displayUrl;
 
     @XmlElement
-    @NotNull
     private URI rpcUrl;
 
     @XmlElement
@@ -69,10 +64,13 @@ public class ApplicationLinkModel {
     private ApplicationLinkAuthType incomingAuthType;
 
     @XmlElement
-    private boolean primary;
+    private Boolean primary;
 
     @XmlElement
     private ApplicationLinkStatus status;
+
+    @XmlElement
+    private Boolean ignoreSetupErrors;
 
     // Example instances for documentation and tests
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryCrowdModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryCrowdModel.java
@@ -22,7 +22,7 @@ import java.net.URI;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @XmlRootElement(name = BootstrAPI.DIRECTORY + '-' + BootstrAPI.DIRECTORY_CROWD)
-public class DirectoryCrowdModel extends AbstractDirectoryModel {
+public class DirectoryCrowdModel extends AbstractDirectoryExternalModel {
 
     @XmlElement
     private DirectoryCrowdServer server;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryDelegatingModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryDelegatingModel.java
@@ -18,7 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @XmlRootElement(name = BootstrAPI.DIRECTORY + '-' + BootstrAPI.DIRECTORY_DELEGATING)
-public class DirectoryDelegatingModel extends AbstractDirectoryModel {
+public class DirectoryDelegatingModel extends AbstractDirectoryExternalModel {
 
     @XmlElement
     private DirectoryDelegatingConnector connector;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryInternalModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryInternalModel.java
@@ -12,8 +12,9 @@ import lombok.Builder;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Model for directory settings in REST requests.
@@ -39,10 +40,10 @@ public class DirectoryInternalModel extends AbstractDirectoryModel {
     // in external directories also, so we just start with the internal directory for now.
 
     @XmlElement
-    private List<GroupModel> groups;
+    private Map<String, GroupModel> groups;
 
     @XmlElement
-    private List<UserModel> users;
+    private Map<String, UserModel> users;
 
     @Data
     @Builder
@@ -108,8 +109,8 @@ public class DirectoryInternalModel extends AbstractDirectoryModel {
             .removeGroup(true)
             .removeUser(true)
             .build())
-        .groups(Collections.singletonList(GroupModel.EXAMPLE_1))
-        .users(Collections.singletonList(UserModel.EXAMPLE_1))
+        .groups(Collections.singletonMap(GroupModel.EXAMPLE_1.getName(), GroupModel.EXAMPLE_1))
+        .users(Collections.singletonMap(UserModel.EXAMPLE_1.getUsername(), UserModel.EXAMPLE_1))
         .build();
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryLdapModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryLdapModel.java
@@ -21,7 +21,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @XmlRootElement(name = BootstrAPI.DIRECTORY + '-' + BootstrAPI.DIRECTORY_LDAP)
-public class DirectoryLdapModel extends AbstractDirectoryModel {
+public class DirectoryLdapModel extends AbstractDirectoryExternalModel {
 
     @XmlElement
     private DirectoryLdapServer server;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/util/ApplicationLinkModelUtil.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/util/ApplicationLinkModelUtil.java
@@ -79,7 +79,7 @@ public class ApplicationLinkModelUtil {
                 .name(applicationLinkModel.getName())
                 .displayUrl(applicationLinkModel.getDisplayUrl())
                 .rpcUrl(applicationLinkModel.getRpcUrl())
-                .isPrimary(applicationLinkModel.isPrimary())
+                .isPrimary(applicationLinkModel.getPrimary())
                 .build();
     }
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinkResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinkResourceImpl.java
@@ -4,7 +4,6 @@ import com.deftdevs.bootstrapi.commons.model.ApplicationLinkModel;
 import com.deftdevs.bootstrapi.commons.rest.api.ApplicationLinkResource;
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 
-import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 public abstract class AbstractApplicationLinkResourceImpl implements ApplicationLinkResource {
@@ -18,39 +17,31 @@ public abstract class AbstractApplicationLinkResourceImpl implements Application
     }
 
     @Override
-    public Response getApplicationLink(
+    public ApplicationLinkModel getApplicationLink(
             final UUID uuid) {
 
-        final ApplicationLinkModel linkModel = applicationLinksService.getApplicationLink(uuid);
-        return Response.ok(linkModel).build();
+        return applicationLinksService.getApplicationLink(uuid);
     }
 
     @Override
-    public Response createApplicationLink(
-            final boolean ignoreSetupErrors,
-            final ApplicationLinkModel linkModel) {
+    public ApplicationLinkModel createApplicationLink(
+            final ApplicationLinkModel applicationLinkModel) {
 
-        final ApplicationLinkModel addedApplicationLink = applicationLinksService.addApplicationLink(
-                linkModel, ignoreSetupErrors);
-        return Response.ok(addedApplicationLink).build();
+        return applicationLinksService.addApplicationLink(applicationLinkModel);
     }
 
     @Override
-    public Response updateApplicationLink(
+    public ApplicationLinkModel updateApplicationLink(
             final UUID uuid,
-            final boolean ignoreSetupErrors,
-            final ApplicationLinkModel linkModel) {
+            final ApplicationLinkModel applicationLinkModel) {
 
-        final ApplicationLinkModel updatedLinkModel = applicationLinksService.setApplicationLink(
-                uuid, linkModel, ignoreSetupErrors);
-        return Response.ok(updatedLinkModel).build();
+        return applicationLinksService.setApplicationLink(uuid, applicationLinkModel);
     }
 
     @Override
-    public Response deleteApplicationLink(
+    public void deleteApplicationLink(
             final UUID uuid) {
 
         applicationLinksService.deleteApplicationLink(uuid);
-        return Response.ok().build();
     }
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceImpl.java
@@ -4,8 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.ApplicationLinkModel;
 import com.deftdevs.bootstrapi.commons.rest.api.ApplicationLinksResource;
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 
-import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
 public abstract class AbstractApplicationLinksResourceImpl implements ApplicationLinksResource {
 
@@ -18,26 +17,21 @@ public abstract class AbstractApplicationLinksResourceImpl implements Applicatio
     }
 
     @Override
-    public Response getApplicationLinks() {
-        final List<ApplicationLinkModel> applicationLinkModels = applicationLinksService.getApplicationLinks();
-        return Response.ok(applicationLinkModels).build();
+    public Map<String, ApplicationLinkModel> getApplicationLinks() {
+        return applicationLinksService.getApplicationLinks();
     }
 
     @Override
-    public Response setApplicationLinks(
-            final boolean ignoreSetupErrors,
-            final List<ApplicationLinkModel> applicationLinkModels) {
+    public Map<String, ApplicationLinkModel> setApplicationLinks(
+            final Map<String, ApplicationLinkModel> applicationLinkModels) {
 
-        final List<ApplicationLinkModel> updatedApplicationLinkModels = applicationLinksService.setApplicationLinks(
-                applicationLinkModels, ignoreSetupErrors);
-        return Response.ok(updatedApplicationLinkModels).build();
+        return applicationLinksService.setApplicationLinks(applicationLinkModels);
     }
 
     @Override
-    public Response deleteApplicationLinks(
+    public void deleteApplicationLinks(
             final boolean force) {
 
         applicationLinksService.deleteApplicationLinks(force);
-        return Response.ok().build();
     }
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractAuthenticationResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractAuthenticationResourceImpl.java
@@ -5,11 +5,10 @@ import com.deftdevs.bootstrapi.commons.model.AuthenticationSsoModel;
 import com.deftdevs.bootstrapi.commons.rest.api.AuthenticationResource;
 import com.deftdevs.bootstrapi.commons.service.api.AuthenticationService;
 
-import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
-public abstract class AbstractAuthenticationResourceImpl<IB extends AbstractAuthenticationIdpModel, SB extends AuthenticationSsoModel, S extends AuthenticationService<IB, SB>>
-        implements AuthenticationResource<IB, SB> {
+public abstract class AbstractAuthenticationResourceImpl<IM extends AbstractAuthenticationIdpModel, SM extends AuthenticationSsoModel, S extends AuthenticationService<IM, SM>>
+        implements AuthenticationResource<IM, SM> {
 
     private final S authenticationService;
 
@@ -20,31 +19,27 @@ public abstract class AbstractAuthenticationResourceImpl<IB extends AbstractAuth
     }
 
     @Override
-    public Response getAuthenticationIdps() {
-        final List<IB> resultAuthenticationIdpModels = authenticationService.getAuthenticationIdps();
-        return Response.ok(resultAuthenticationIdpModels).build();
+    public Map<String, ? extends IM> getAuthenticationIdps() {
+        return authenticationService.getAuthenticationIdps();
     }
 
     @Override
-    public Response setAuthenticationIdps(
-            final List<IB> authenticationIdpModels) {
+    public Map<String, ? extends IM> setAuthenticationIdps(
+            final Map<String, ? extends IM> authenticationIdpModels) {
 
-        final List<IB> resultAuthenticationIdpModels = authenticationService.setAuthenticationIdps(authenticationIdpModels);
-        return Response.ok(resultAuthenticationIdpModels).build();
+        return authenticationService.setAuthenticationIdps(authenticationIdpModels);
     }
 
     @Override
-    public Response getAuthenticationSso() {
-        final SB resultAuthenticationSsoModel = authenticationService.getAuthenticationSso();
-        return Response.ok(resultAuthenticationSsoModel).build();
+    public SM getAuthenticationSso() {
+        return authenticationService.getAuthenticationSso();
     }
 
     @Override
-    public Response setAuthenticationSso(
-            final SB authenticationSsoModel) {
+    public SM setAuthenticationSso(
+            final SM authenticationSsoModel) {
 
-        final SB resultAuthenticationSsoModel = authenticationService.setAuthenticationSso(authenticationSsoModel);
-        return Response.ok(resultAuthenticationSsoModel).build();
+        return authenticationService.setAuthenticationSso(authenticationSsoModel);
     }
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoriesResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoriesResourceImpl.java
@@ -4,37 +4,35 @@ import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
 import com.deftdevs.bootstrapi.commons.rest.api.DirectoriesResource;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 
-import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
 public abstract class AbstractDirectoriesResourceImpl implements DirectoriesResource {
 
     private final DirectoriesService directoriesService;
 
-    public AbstractDirectoriesResourceImpl(DirectoriesService directoriesService) {
+    public AbstractDirectoriesResourceImpl(
+            final DirectoriesService directoriesService) {
+
         this.directoriesService = directoriesService;
     }
 
     @Override
-    public Response getDirectories() {
-        final List<AbstractDirectoryModel> directoryModels = directoriesService.getDirectories();
-        return Response.ok(directoryModels).build();
+    public Map<String, ? extends AbstractDirectoryModel> getDirectories() {
+        return directoriesService.getDirectories();
     }
 
     @Override
-    public Response setDirectories (
-            final boolean testConnection,
-            final List<AbstractDirectoryModel> directories) {
+    public Map<String, ? extends AbstractDirectoryModel> setDirectories (
+            final Map<String, ? extends AbstractDirectoryModel> directories) {
 
-        List<AbstractDirectoryModel> directoryModels = directoriesService.setDirectories(directories, testConnection);
-        return Response.ok(directoryModels).build();
+        return directoriesService.setDirectories(directories);
     }
 
     @Override
-    public Response deleteDirectories(
+    public void deleteDirectories(
             final boolean force) {
+
         directoriesService.deleteDirectories(force);
-        return Response.ok().build();
     }
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoryResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoryResourceImpl.java
@@ -15,35 +15,31 @@ public abstract class AbstractDirectoryResourceImpl implements DirectoryResource
     }
 
     @Override
-    public Response getDirectory(
+    public AbstractDirectoryModel getDirectory(
             final long id) {
-        final AbstractDirectoryModel directoryModel = directoriesService.getDirectory(id);
-        return Response.ok(directoryModel).build();
+
+        return directoriesService.getDirectory(id);
     }
 
     @Override
-    public Response updateDirectory(
+    public AbstractDirectoryModel updateDirectory(
             final long id,
-            final boolean testConnection,
             final AbstractDirectoryModel directory) {
 
-        AbstractDirectoryModel resultDirectoryModel  = directoriesService.setDirectory(id, directory, testConnection);
-        return Response.ok(resultDirectoryModel).build();
+        return directoriesService.setDirectory(id, directory);
     }
 
     @Override
-    public Response createDirectory(
-            final boolean testConnection,
+    public AbstractDirectoryModel createDirectory(
             final AbstractDirectoryModel directory) {
 
-        AbstractDirectoryModel addedDirectoryModel = directoriesService.addDirectory(directory, testConnection);
-        return Response.ok(addedDirectoryModel).build();
+        return directoriesService.addDirectory(directory);
     }
 
     @Override
-    public Response deleteDirectory(
+    public void deleteDirectory(
             final long id) {
+
         directoriesService.deleteDirectory(id);
-        return Response.ok().build();
     }
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinkResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinkResource.java
@@ -8,9 +8,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 public interface ApplicationLinkResource {
@@ -33,7 +39,7 @@ public interface ApplicationLinkResource {
                     ),
             }
     )
-    Response getApplicationLink(
+    ApplicationLinkModel getApplicationLink(
             @PathParam("uuid") final UUID uuid);
 
     @POST
@@ -53,8 +59,7 @@ public interface ApplicationLinkResource {
                     ),
             }
     )
-    Response createApplicationLink(
-            @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
+    ApplicationLinkModel createApplicationLink(
             final ApplicationLinkModel linkModel);
 
     @PUT
@@ -75,10 +80,9 @@ public interface ApplicationLinkResource {
                     ),
             }
     )
-    Response updateApplicationLink(
+    ApplicationLinkModel updateApplicationLink(
             @PathParam("uuid") final UUID uuid,
-            @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
-            final ApplicationLinkModel linksModelModels);
+            final ApplicationLinkModel applicationLinkModel);
 
     @DELETE
     @Path("{uuid}")
@@ -96,7 +100,7 @@ public interface ApplicationLinkResource {
                     ),
             }
     )
-    Response deleteApplicationLink(
+    void deleteApplicationLink(
             @PathParam("uuid") final UUID uuid);
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
@@ -9,10 +9,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
 public interface ApplicationLinksResource {
 
@@ -32,7 +36,7 @@ public interface ApplicationLinksResource {
                     ),
             }
     )
-    Response getApplicationLinks();
+    Map<String, ApplicationLinkModel> getApplicationLinks();
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -52,9 +56,8 @@ public interface ApplicationLinksResource {
                     ),
             }
     )
-    Response setApplicationLinks(
-            @QueryParam("ignore-setup-errors") @DefaultValue("false") final boolean ignoreSetupErrors,
-            final List<ApplicationLinkModel> applicationLinkModels);
+    Map<String, ApplicationLinkModel> setApplicationLinks(
+            final Map<String, ApplicationLinkModel> applicationLinkModels);
 
     @DELETE
     @Operation(
@@ -72,7 +75,7 @@ public interface ApplicationLinksResource {
                     ),
             }
     )
-    Response deleteApplicationLinks(
+    void deleteApplicationLinks(
             @QueryParam("force") final boolean force);
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/AuthenticationResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/AuthenticationResource.java
@@ -16,10 +16,9 @@ import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
-public interface AuthenticationResource<IB extends AbstractAuthenticationIdpModel, SB extends AuthenticationSsoModel> {
+public interface AuthenticationResource<IM extends AbstractAuthenticationIdpModel, SM extends AuthenticationSsoModel> {
 
     @GET
     @Path(BootstrAPI.AUTHENTICATION_IDPS)
@@ -37,7 +36,7 @@ public interface AuthenticationResource<IB extends AbstractAuthenticationIdpMode
                     )
             }
     )
-    Response getAuthenticationIdps();
+    Map<String, ? extends IM> getAuthenticationIdps();
 
     @PATCH
     @Path(BootstrAPI.AUTHENTICATION_IDPS)
@@ -56,8 +55,8 @@ public interface AuthenticationResource<IB extends AbstractAuthenticationIdpMode
                     )
             }
     )
-    Response setAuthenticationIdps(
-            final List<IB> authenticationIdpModels);
+    Map<String, ? extends IM> setAuthenticationIdps(
+            final Map<String, ? extends IM> authenticationIdpModels);
 
     @GET
     @Path(BootstrAPI.AUTHENTICATION_SSO)
@@ -75,7 +74,7 @@ public interface AuthenticationResource<IB extends AbstractAuthenticationIdpMode
                     )
             }
     )
-    Response getAuthenticationSso();
+    SM getAuthenticationSso();
 
     @PATCH
     @Path(BootstrAPI.AUTHENTICATION_SSO)
@@ -94,7 +93,7 @@ public interface AuthenticationResource<IB extends AbstractAuthenticationIdpMode
                     )
             }
     )
-    Response setAuthenticationSso(
-            final SB authenticationSsoModel);
+    SM setAuthenticationSso(
+            final SM authenticationSsoModel);
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
@@ -4,15 +4,18 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
 public interface DirectoriesResource {
 
@@ -23,8 +26,8 @@ public interface DirectoriesResource {
             summary = "Get all user directories",
             responses = {
                     @ApiResponse(
-                            responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AbstractDirectoryModel.class))),
-                            description = "Returns all directories."
+                            responseCode = "200", content = @Content(schema = @Schema(type = "object", additionalPropertiesSchema = AbstractDirectoryModel.class)),
+                            description = "Returns directories mapped by their name."
                     ),
                     @ApiResponse(
                             responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
@@ -32,19 +35,19 @@ public interface DirectoriesResource {
                     ),
             }
     )
-    Response getDirectories();
+    Map<String, ? extends AbstractDirectoryModel> getDirectories();
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             tags = { BootstrAPI.DIRECTORIES },
-            summary = "Set a list of user directories",
+            summary = "Set directories mapped by their name.",
             description = "NOTE: All existing directories with the same 'name' attribute are updated.",
             responses = {
                     @ApiResponse(
-                            responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AbstractDirectoryModel.class))),
-                            description = "Returns all directories."
+                            responseCode = "200", content = @Content(schema = @Schema(type = "object", additionalPropertiesSchema = AbstractDirectoryModel.class)),
+                            description = "Returns directories mapped by their name."
                     ),
                     @ApiResponse(
                             responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
@@ -52,9 +55,8 @@ public interface DirectoriesResource {
                     ),
             }
     )
-    Response setDirectories(
-            @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
-            final List<AbstractDirectoryModel> directories);
+    Map<String, ? extends AbstractDirectoryModel> setDirectories(
+            final Map<String, ? extends AbstractDirectoryModel> directories);
 
     @DELETE
     @Operation(
@@ -72,7 +74,7 @@ public interface DirectoriesResource {
                     ),
             }
     )
-    Response deleteDirectories(
+    void deleteDirectories(
             @QueryParam("force") final boolean force);
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoryResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoryResource.java
@@ -8,9 +8,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 public interface DirectoryResource {
 
@@ -31,7 +37,7 @@ public interface DirectoryResource {
                     ),
             }
     )
-    Response getDirectory(
+    AbstractDirectoryModel getDirectory(
             @PathParam("id") final long id);
 
     @POST
@@ -51,8 +57,7 @@ public interface DirectoryResource {
                     ),
             }
     )
-    Response createDirectory(
-            @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
+    AbstractDirectoryModel createDirectory(
             final AbstractDirectoryModel directory);
 
     @PUT
@@ -73,9 +78,8 @@ public interface DirectoryResource {
                     ),
             }
     )
-    Response updateDirectory(
+    AbstractDirectoryModel updateDirectory(
             @PathParam("id") final long id,
-            @QueryParam("test-connection") @DefaultValue("false") final boolean testConnection,
             final AbstractDirectoryModel directory);
 
     @DELETE
@@ -94,7 +98,7 @@ public interface DirectoryResource {
                     ),
             }
     )
-    Response deleteDirectory(
+    void deleteDirectory(
             @PathParam("id") final long id);
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/AbstractDirectoriesService.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/AbstractDirectoriesService.java
@@ -1,0 +1,49 @@
+package com.deftdevs.bootstrapi.commons.service;
+
+import com.deftdevs.bootstrapi.commons.exception.web.BadRequestException;
+import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
+import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public abstract class AbstractDirectoriesService implements DirectoriesService {
+
+    @Override
+    public Map<String, ? extends AbstractDirectoryModel> setDirectories(
+            final Map<String, ? extends AbstractDirectoryModel> directoryModels) {
+
+        final Map<String, AbstractDirectoryModel> existingDirectoriesByName = getDirectories().values().stream()
+                .collect(Collectors.toMap(AbstractDirectoryModel::getName, Function.identity()));
+
+        final Map<String, AbstractDirectoryModel> resultDirectories = new LinkedHashMap<>();
+
+        for (Map.Entry<String, ? extends AbstractDirectoryModel> directoryModelEntry : directoryModels.entrySet()) {
+            final AbstractDirectoryModel directoryModel = directoryModelEntry.getValue();
+
+            // Check if directoryModel is not an instance of any supported class
+            if (getSupportedClassesForUpdate().stream().noneMatch(clazz -> clazz.isInstance(directoryModel))) {
+                throw new BadRequestException(String.format("Updating directory type '%s' is not supported (yet)", directoryModel.getClass()));
+            }
+
+            final AbstractDirectoryModel existingDirectoryModel = existingDirectoriesByName.get(directoryModelEntry.getKey());
+            final AbstractDirectoryModel resultDirectoryModel;
+
+            if (existingDirectoryModel != null) {
+                resultDirectoryModel = setDirectory(existingDirectoryModel.getId(), directoryModelEntry.getValue());
+            } else {
+                resultDirectoryModel = addDirectory(directoryModelEntry.getValue());
+            }
+
+            resultDirectories.put(resultDirectoryModel.getName(), resultDirectoryModel);
+        }
+
+        return resultDirectories;
+    }
+
+    protected abstract Set<Class<? extends AbstractDirectoryModel>> getSupportedClassesForUpdate();
+
+}

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/ApplicationLinksService.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/ApplicationLinksService.java
@@ -2,7 +2,7 @@ package com.deftdevs.bootstrapi.commons.service.api;
 
 import com.deftdevs.bootstrapi.commons.model.ApplicationLinkModel;
 
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface ApplicationLinksService {
@@ -12,7 +12,7 @@ public interface ApplicationLinksService {
      *
      * @return the application links
      */
-    List<ApplicationLinkModel> getApplicationLinks();
+    Map<String, ApplicationLinkModel> getApplicationLinks();
 
     /**
      * Gets a single application link.
@@ -27,39 +27,30 @@ public interface ApplicationLinksService {
      * Sets or updates the given application links
      *
      * @param applicationLinkModels the application links to set / update
-     * @param ignoreSetupErrors    whether or not to ignore authentication or other setup errors when setting up the link
-     *                             which usually happens if the application to link has not setup the link counterpart yet
      * @return the updated application links
      */
-    List<ApplicationLinkModel> setApplicationLinks(
-            final List<ApplicationLinkModel> applicationLinkModels,
-            boolean ignoreSetupErrors);
+    Map<String, ApplicationLinkModel> setApplicationLinks(
+            final Map<String, ApplicationLinkModel> applicationLinkModels);
 
     /**
      * Updates the given application link
      *
-     * @param uuid                the application link uuid to update
+     * @param uuid                 the application link uuid to update
      * @param applicationLinkModel the application link to set / update
-     * @param ignoreSetupErrors   whether or not to ignore authentication or other setup errors when setting up the link
-     *                            which usually happens if the application to link has not setup the link counterpart yet
      * @return the updated application link
      */
     ApplicationLinkModel setApplicationLink(
             final UUID uuid,
-            final ApplicationLinkModel applicationLinkModel,
-            boolean ignoreSetupErrors);
+            final ApplicationLinkModel applicationLinkModel);
 
     /**
      * Adds a single application link
      *
      * @param applicationLinkModel the application link to set
-     * @param ignoreSetupErrors   whether or not to ignore authentication or other setup errors when setting up the link
-     *                            which usually happens if the application to link has not setup the link counterpart yet
      * @return the added application link
      */
     ApplicationLinkModel addApplicationLink(
-            final ApplicationLinkModel applicationLinkModel,
-            boolean ignoreSetupErrors);
+            final ApplicationLinkModel applicationLinkModel);
 
     /**
      * Deletes all application links

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/AuthenticationService.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/AuthenticationService.java
@@ -3,14 +3,14 @@ package com.deftdevs.bootstrapi.commons.service.api;
 import com.deftdevs.bootstrapi.commons.model.AbstractAuthenticationIdpModel;
 import com.deftdevs.bootstrapi.commons.model.AuthenticationSsoModel;
 
-import java.util.List;
+import java.util.Map;
 
 public interface AuthenticationService<IB extends AbstractAuthenticationIdpModel, SB extends AuthenticationSsoModel> {
 
-    List<IB> getAuthenticationIdps();
+    Map<String, ? extends IB> getAuthenticationIdps();
 
-    List<IB> setAuthenticationIdps(
-            List<IB> authenticationIdpModels);
+    Map<String, ? extends IB> setAuthenticationIdps(
+            Map<String, ? extends IB> authenticationIdpModels);
 
     IB setAuthenticationIdp(
             IB authenticationIdpModel);

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/DirectoriesService.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/DirectoriesService.java
@@ -2,7 +2,7 @@ package com.deftdevs.bootstrapi.commons.service.api;
 
 import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * The User directory service interface.
@@ -14,7 +14,7 @@ public interface DirectoriesService {
      *
      * @return the directories
      */
-    List<AbstractDirectoryModel> getDirectories();
+    Map<String, ? extends AbstractDirectoryModel> getDirectories();
 
     /**
      * Gets a single directory.
@@ -26,39 +26,33 @@ public interface DirectoriesService {
             final long id);
 
     /**
-     * Adds or Updates directory configurations. Any existing configurations with the same 'name' property is updated.
+     * Adds or Updates directory configurations. Any existing configurations with the same key is updated.
      *
-     * @param directories    the directories
-     * @param testConnection whether to test connection
+     * @param directoryModels the directories
      * @return the directories
      */
-    List<AbstractDirectoryModel> setDirectories(
-            List<AbstractDirectoryModel> directories,
-            boolean testConnection);
+    Map<String, ? extends AbstractDirectoryModel> setDirectories(
+            Map<String, ? extends AbstractDirectoryModel> directoryModels);
 
     /**
      * Updates a single directory configuration. Any existing configuration with the same 'name' property is updated.
      *
      * @param id             the directory id to update
-     * @param directory      the directory
-     * @param testConnection whether to test connection
+     * @param directoryModel the directory
      * @return the directories
      */
     AbstractDirectoryModel setDirectory(
             long id,
-            AbstractDirectoryModel directory,
-            boolean testConnection);
+            AbstractDirectoryModel directoryModel);
 
     /**
      * Adds a new directory configuration.
      *
-     * @param directory      the directories
-     * @param testConnection whether to test connection
+     * @param directoryModel the directories
      * @return the added directory
      */
     AbstractDirectoryModel addDirectory(
-            AbstractDirectoryModel directory,
-            boolean testConnection);
+            AbstractDirectoryModel directoryModel);
 
     /**
      * Deletes all directories

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/UsersService.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/UsersService.java
@@ -2,7 +2,7 @@ package com.deftdevs.bootstrapi.commons.service.api;
 
 import com.deftdevs.bootstrapi.commons.model.UserModel;
 
-import java.util.List;
+import java.util.Map;
 
 public interface UsersService {
 
@@ -44,9 +44,9 @@ public interface UsersService {
      * @param userModels the user beans
      * @return the set user beans
      */
-    List<UserModel> setUsers(
+    Map<String, UserModel> setUsers(
             final long directoryId,
-            final List<UserModel> userModels);
+            final Map<String, UserModel> userModels);
 
     /**
      * Update the user.

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/util/ApplicationLinkModelUtilTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/util/ApplicationLinkModelUtilTest.java
@@ -44,7 +44,7 @@ class ApplicationLinkModelUtilTest {
         assertEquals(bean.getName(), applicationLink.getName());
         assertEquals(bean.getDisplayUrl(), applicationLink.getDisplayUrl());
         assertEquals(bean.getRpcUrl(), applicationLink.getRpcUrl());
-        assertEquals(bean.isPrimary(), applicationLink.isPrimary());
+        assertEquals(bean.getPrimary(), applicationLink.isPrimary());
     }
 
     @Test
@@ -56,7 +56,7 @@ class ApplicationLinkModelUtilTest {
         assertEquals(bean.getName(), linkDetails.getName());
         assertEquals(bean.getDisplayUrl(), linkDetails.getDisplayUrl());
         assertEquals(bean.getRpcUrl(), linkDetails.getRpcUrl());
-        assertEquals(bean.isPrimary(), linkDetails.isPrimary());
+        assertEquals(bean.getPrimary(), linkDetails.isPrimary());
     }
 
     @Test

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/ApplicationLinkResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/ApplicationLinkResourceTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,42 +31,29 @@ class ApplicationLinkResourceTest {
     @Test
     void testGetApplicationLink() {
         final ApplicationLinkModel bean = ApplicationLinkModel.EXAMPLE_1;
-
-        UUID id = UUID.randomUUID();
-
+        final UUID id = UUID.randomUUID();
         doReturn(bean).when(applicationLinksService).getApplicationLink(id);
 
-        final Response response = resource.getApplicationLink(id);
-        assertEquals(200, response.getStatus());
-        final ApplicationLinkModel linkModel = (ApplicationLinkModel) response.getEntity();
-
+        final ApplicationLinkModel linkModel = resource.getApplicationLink(id);
         assertEquals(linkModel, bean);
     }
 
     @Test
     void testCreateApplicationLink() {
         final ApplicationLinkModel bean = ApplicationLinkModel.EXAMPLE_1;
+        doReturn(bean).when(applicationLinksService).addApplicationLink(bean);
 
-        doReturn(bean).when(applicationLinksService).addApplicationLink(bean, true);
-
-        final Response response = resource.createApplicationLink(true, bean);
-        assertEquals(200, response.getStatus());
-        final ApplicationLinkModel responseModel = (ApplicationLinkModel) response.getEntity();
-
+        final ApplicationLinkModel responseModel = resource.createApplicationLink(bean);
         assertEquals(responseModel, bean);
     }
 
     @Test
     void testUpdateApplicationLink() {
         final ApplicationLinkModel bean = ApplicationLinkModel.EXAMPLE_1;
-        UUID id = UUID.randomUUID();
+        final UUID id = UUID.randomUUID();
+        doReturn(bean).when(applicationLinksService).setApplicationLink(id, bean);
 
-        doReturn(bean).when(applicationLinksService).setApplicationLink(id, bean, true);
-
-        final Response response = resource.updateApplicationLink(id, true, bean);
-        assertEquals(200, response.getStatus());
-        final ApplicationLinkModel linkModel = (ApplicationLinkModel) response.getEntity();
-
+        final ApplicationLinkModel linkModel = resource.updateApplicationLink(id, bean);
         assertEquals(linkModel, bean);
     }
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/ApplicationLinksResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/ApplicationLinksResourceTest.java
@@ -9,9 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,25 +31,19 @@ class ApplicationLinksResourceTest {
 
     @Test
     void testGetApplicationLinks() {
-        final List<ApplicationLinkModel> applicationLinkModels = Collections.singletonList(ApplicationLinkModel.EXAMPLE_1);
+        final Map<String, ApplicationLinkModel> applicationLinkModels = Collections.singletonMap(ApplicationLinkModel.EXAMPLE_1.getName(), ApplicationLinkModel.EXAMPLE_1);
         doReturn(applicationLinkModels).when(applicationLinksService).getApplicationLinks();
 
-        final Response response = resource.getApplicationLinks();
-        assertEquals(200, response.getStatus());
-
-        final List<ApplicationLinkModel> responseApplicationLinkModels = (List<ApplicationLinkModel>) response.getEntity();
+        final Map<String, ApplicationLinkModel> responseApplicationLinkModels = resource.getApplicationLinks();
         assertEquals(responseApplicationLinkModels, applicationLinkModels);
     }
 
     @Test
     void testSetApplicationLinks() {
-        final List<ApplicationLinkModel> applicationLinkModels = Collections.singletonList(ApplicationLinkModel.EXAMPLE_1);
-        doReturn(applicationLinkModels).when(applicationLinksService).setApplicationLinks(applicationLinkModels, true);
+        final Map<String, ApplicationLinkModel> applicationLinkModels = Collections.singletonMap(ApplicationLinkModel.EXAMPLE_1.getName(), ApplicationLinkModel.EXAMPLE_1);
+        doReturn(applicationLinkModels).when(applicationLinksService).setApplicationLinks(applicationLinkModels);
 
-        final Response response = resource.setApplicationLinks(true, applicationLinkModels);
-        assertEquals(200, response.getStatus());
-
-        final List<ApplicationLinkModel> resultApplicationLinkModels = (List<ApplicationLinkModel>) response.getEntity();
+        final Map<String, ApplicationLinkModel> resultApplicationLinkModels = resource.setApplicationLinks(applicationLinkModels);
         assertEquals(resultApplicationLinkModels, applicationLinkModels);
     }
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/AuthenticationResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/AuthenticationResourceTest.java
@@ -12,9 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -23,7 +21,7 @@ import static org.mockito.Mockito.doReturn;
 class AuthenticationResourceTest {
 
     @Mock
-    private AuthenticationService authenticationService;
+    private AuthenticationService<AbstractAuthenticationIdpModel, AuthenticationSsoModel> authenticationService;
 
     private TestAuthenticationResourceImpl resource;
 
@@ -34,31 +32,25 @@ class AuthenticationResourceTest {
 
     @Test
     void testGetAuthenticationIdps() {
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModels = Arrays.asList(
-                AuthenticationIdpOidcModel.EXAMPLE_1,
-                AuthenticationIdpSamlModel.EXAMPLE_1
+        final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModels = Map.of(
+                AuthenticationIdpOidcModel.EXAMPLE_1.getName(), AuthenticationIdpOidcModel.EXAMPLE_1,
+                AuthenticationIdpSamlModel.EXAMPLE_1.getName(), AuthenticationIdpSamlModel.EXAMPLE_1
         );
         doReturn(authenticationIdpModels).when(authenticationService).getAuthenticationIdps();
 
-        final Response response = resource.getAuthenticationIdps();
-        assertEquals(200, response.getStatus());
-
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModelsResponse = (List<AbstractAuthenticationIdpModel>) response.getEntity();
+        final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModelsResponse = resource.getAuthenticationIdps();
         assertEquals(authenticationIdpModels, authenticationIdpModelsResponse);
     }
 
     @Test
     void testSetAuthenticationIdps() {
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModels = Arrays.asList(
-                AuthenticationIdpOidcModel.EXAMPLE_1,
-                AuthenticationIdpSamlModel.EXAMPLE_1
+        final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModels = Map.of(
+                AuthenticationIdpOidcModel.EXAMPLE_1.getName(), AuthenticationIdpOidcModel.EXAMPLE_1,
+                AuthenticationIdpSamlModel.EXAMPLE_1.getName(), AuthenticationIdpSamlModel.EXAMPLE_1
         );
         doReturn(authenticationIdpModels).when(authenticationService).setAuthenticationIdps(authenticationIdpModels);
 
-        final Response response = resource.setAuthenticationIdps(authenticationIdpModels);
-        assertEquals(200, response.getStatus());
-
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModelsResponse = (List<AbstractAuthenticationIdpModel>) response.getEntity();
+        final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModelsResponse = resource.setAuthenticationIdps(authenticationIdpModels);
         assertEquals(authenticationIdpModels, authenticationIdpModelsResponse);
     }
 
@@ -67,10 +59,7 @@ class AuthenticationResourceTest {
         final AuthenticationSsoModel authenticationSsoModel = AuthenticationSsoModel.EXAMPLE_1;
         doReturn(authenticationSsoModel).when(authenticationService).getAuthenticationSso();
 
-        final Response response = resource.getAuthenticationSso();
-        assertEquals(200, response.getStatus());
-
-        final AuthenticationSsoModel authenticationSsoModelResponse = (AuthenticationSsoModel) response.getEntity();
+        final AuthenticationSsoModel authenticationSsoModelResponse = resource.getAuthenticationSso();
         assertEquals(authenticationSsoModel, authenticationSsoModelResponse);
     }
 
@@ -79,10 +68,7 @@ class AuthenticationResourceTest {
         final AuthenticationSsoModel authenticationSsoModel = AuthenticationSsoModel.EXAMPLE_1;
         doReturn(authenticationSsoModel).when(authenticationService).setAuthenticationSso(authenticationSsoModel);
 
-        final Response response = resource.setAuthenticationSso(authenticationSsoModel);
-        assertEquals(200, response.getStatus());
-
-        final AuthenticationSsoModel authenticationSsoModelResponse = (AuthenticationSsoModel) response.getEntity();
+        final AuthenticationSsoModel authenticationSsoModelResponse = resource.setAuthenticationSso(authenticationSsoModel);
         assertEquals(authenticationSsoModel, authenticationSsoModelResponse);
     }
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/DirectoriesResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/DirectoriesResourceTest.java
@@ -10,10 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,27 +36,22 @@ class DirectoriesResourceTest {
     @Test
     void testGetDirectories() {
         final DirectoryCrowdModel initialDirectoryModel = DirectoryCrowdModel.EXAMPLE_1;
-        final List<AbstractDirectoryModel> directoryModels = Collections.singletonList(initialDirectoryModel);
+        final Map<String, AbstractDirectoryModel> directoryModels = Collections.singletonMap(initialDirectoryModel.getName(), initialDirectoryModel);
         doReturn(directoryModels).when(directoriesService).getDirectories();
 
-        final Response response = resource.getDirectories();
-        assertEquals(200, response.getStatus());
-
-        final List<AbstractDirectoryModel> responseDirectoryModels = (List<AbstractDirectoryModel>) response.getEntity();
-        assertEquals(initialDirectoryModel, responseDirectoryModels.iterator().next());
+        final Map<String, ? extends AbstractDirectoryModel> responseDirectoryModels = resource.getDirectories();
+        assertEquals(initialDirectoryModel, responseDirectoryModels.values().iterator().next());
     }
 
     @Test
     void testSetDirectories() {
         final DirectoryCrowdModel directoryModel1 = DirectoryCrowdModel.EXAMPLE_1;
         final DirectoryCrowdModel directoryModel2 = DirectoryCrowdModel.EXAMPLE_3;
-        final List<AbstractDirectoryModel> directoryModels = Arrays.asList(directoryModel1, directoryModel2);
-        doReturn(directoryModels).when(directoriesService).setDirectories(directoryModels, false);
+        final Map<String, ? extends AbstractDirectoryModel> directoryModels = Stream.of(directoryModel1, directoryModel2)
+                        .collect(Collectors.toMap(AbstractDirectoryModel::getName, Function.identity()));
+        doReturn(directoryModels).when(directoriesService).setDirectories(directoryModels);
 
-        final Response response = resource.setDirectories(Boolean.FALSE, directoryModels);
-        assertEquals(200, response.getStatus());
-
-        final List<AbstractDirectoryModel> responseDirectoryModels = (List<AbstractDirectoryModel>) response.getEntity();
+        final Map<String, ? extends AbstractDirectoryModel> responseDirectoryModels = resource.setDirectories(directoryModels);
         assertEquals(directoryModels.size(), responseDirectoryModels.size());
     }
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/DirectoryResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/DirectoryResourceTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -32,39 +30,27 @@ class DirectoryResourceTest {
     @Test
     void testGetDirectory() {
         DirectoryCrowdModel directoryModel = DirectoryCrowdModel.EXAMPLE_1;
-
         doReturn(directoryModel).when(directoriesService).getDirectory(1L);
 
-        final Response response = resource.getDirectory(1L);
-        assertEquals(200, response.getStatus());
-        final AbstractDirectoryModel directoryModelResponse = (AbstractDirectoryModel) response.getEntity();
-
+        final AbstractDirectoryModel directoryModelResponse = resource.getDirectory(1L);
         assertEquals(directoryModel, directoryModelResponse);
     }
 
     @Test
     void testCreateDirectory() {
         DirectoryCrowdModel bean = DirectoryCrowdModel.EXAMPLE_1;
+        doReturn(bean).when(directoriesService).addDirectory(bean);
 
-        doReturn(bean).when(directoriesService).addDirectory(bean, false);
-
-        final Response response = resource.createDirectory(Boolean.FALSE, bean);
-        assertEquals(200, response.getStatus());
-        final AbstractDirectoryModel responseModel = (AbstractDirectoryModel) response.getEntity();
-
+        final AbstractDirectoryModel responseModel = resource.createDirectory(bean);
         assertEquals(bean.getName(), responseModel.getName());
     }
 
     @Test
     void testUpdateDirectory() {
         DirectoryCrowdModel directoryModel = DirectoryCrowdModel.EXAMPLE_1;
+        doReturn(directoryModel).when(directoriesService).setDirectory(1L, directoryModel);
 
-        doReturn(directoryModel).when(directoriesService).setDirectory(1L, directoryModel, false);
-
-        final Response response = resource.updateDirectory(1L, Boolean.FALSE, directoryModel);
-        assertEquals(200, response.getStatus());
-        final AbstractDirectoryModel directoryModelResponse = (AbstractDirectoryModel) response.getEntity();
-
+        final AbstractDirectoryModel directoryModelResponse = resource.updateDirectory(1L, directoryModel);
         assertEquals(directoryModel, directoryModelResponse);
     }
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/impl/TestAuthenticationResourceImpl.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/impl/TestAuthenticationResourceImpl.java
@@ -1,11 +1,15 @@
 package com.deftdevs.bootstrapi.commons.rest.impl;
 
+import com.deftdevs.bootstrapi.commons.model.AbstractAuthenticationIdpModel;
+import com.deftdevs.bootstrapi.commons.model.AuthenticationSsoModel;
 import com.deftdevs.bootstrapi.commons.rest.AbstractAuthenticationResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.AuthenticationService;
 
-public class TestAuthenticationResourceImpl extends AbstractAuthenticationResourceImpl {
+public class TestAuthenticationResourceImpl extends AbstractAuthenticationResourceImpl<AbstractAuthenticationIdpModel, AuthenticationSsoModel, AuthenticationService<AbstractAuthenticationIdpModel, AuthenticationSsoModel>> {
 
-    public TestAuthenticationResourceImpl(AuthenticationService authenticationService) {
+    public TestAuthenticationResourceImpl(
+            AuthenticationService<AbstractAuthenticationIdpModel, AuthenticationSsoModel> authenticationService) {
+
         super(authenticationService);
     }
 

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceFuncTest.java
@@ -10,9 +10,10 @@ import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractApplicationLinksResourceFuncTest {
 
@@ -28,14 +29,14 @@ public abstract class AbstractApplicationLinksResourceFuncTest {
     void testSetApplicationLinks() throws Exception {
         final ApplicationLinkModel applicationLinkModel = getExampleModel();
 
-        final HttpResponse<String> applicationLinksResponse = HttpRequestHelper.builder(BootstrAPI.APPLICATION_LINKS + "?" + "ignore-setup-errors=true")
-                .request(HttpMethod.PUT, Collections.singletonList(applicationLinkModel));
+        final HttpResponse<String> applicationLinksResponse = HttpRequestHelper.builder(BootstrAPI.APPLICATION_LINKS)
+                .request(HttpMethod.PUT, Collections.singletonMap(applicationLinkModel.getName(), applicationLinkModel));
         assertEquals(Response.Status.OK.getStatusCode(), applicationLinksResponse.statusCode(), applicationLinksResponse.body());
 
-        final List<ApplicationLinkModel> applicationLinkModels = objectMapper.readValue(applicationLinksResponse.body(), new TypeReference<List<ApplicationLinkModel>>(){});
-        assertEquals(1, applicationLinkModels.size());
+        final Map<String, ApplicationLinkModel> applicationLinkModels = objectMapper.readValue(applicationLinksResponse.body(), new TypeReference<Map<String, ApplicationLinkModel>>(){});
+        assertTrue(applicationLinkModels.containsKey(applicationLinkModel.getName()));
 
-        final ApplicationLinkModel responseApplicationLinkModel = applicationLinkModels.iterator().next();
+        final ApplicationLinkModel responseApplicationLinkModel = applicationLinkModels.get(applicationLinkModel.getName());
         assertEquals(applicationLinkModel.getRpcUrl(), responseApplicationLinkModel.getRpcUrl());
     }
 
@@ -58,7 +59,16 @@ public abstract class AbstractApplicationLinksResourceFuncTest {
     }
 
     protected ApplicationLinkModel getExampleModel() {
-        return ApplicationLinkModel.EXAMPLE_1;
+        return ApplicationLinkModel.builder()
+                .name(ApplicationLinkModel.EXAMPLE_1.getName())
+                .displayUrl(ApplicationLinkModel.EXAMPLE_1.getDisplayUrl())
+                .rpcUrl(ApplicationLinkModel.EXAMPLE_1.getRpcUrl())
+                .outgoingAuthType(ApplicationLinkModel.EXAMPLE_1.getOutgoingAuthType())
+                .incomingAuthType(ApplicationLinkModel.EXAMPLE_1.getIncomingAuthType())
+                .primary(ApplicationLinkModel.EXAMPLE_1.getPrimary())
+                .type(ApplicationLinkModel.EXAMPLE_1.getType())
+                .ignoreSetupErrors(true)
+                .build();
     }
 
 }

--- a/confluence/Apis/ApplicationLinkApi.md
+++ b/confluence/Apis/ApplicationLinkApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *https://CONFLUENCE_URL/rest/bootstrapi/1*
 
 <a name="createApplicationLink"></a>
 # **createApplicationLink**
-> ApplicationLinkModel createApplicationLink(ignore-setup-errors, ApplicationLinkModel)
+> ApplicationLinkModel createApplicationLink(ApplicationLinkModel)
 
 Create an application link
 
@@ -20,7 +20,6 @@ Create an application link
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
 | **ApplicationLinkModel** | [**ApplicationLinkModel**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type
@@ -90,7 +89,7 @@ Get an application link
 
 <a name="updateApplicationLink"></a>
 # **updateApplicationLink**
-> ApplicationLinkModel updateApplicationLink(uuid, ignore-setup-errors, ApplicationLinkModel)
+> ApplicationLinkModel updateApplicationLink(uuid, ApplicationLinkModel)
 
 Update an application link
 
@@ -99,7 +98,6 @@ Update an application link
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **uuid** | **UUID**|  | [default to null] |
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
 | **ApplicationLinkModel** | [**ApplicationLinkModel**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type

--- a/confluence/Apis/ApplicationLinksApi.md
+++ b/confluence/Apis/ApplicationLinksApi.md
@@ -60,7 +60,7 @@ This endpoint does not need any parameter.
 
 <a name="setApplicationLinks"></a>
 # **setApplicationLinks**
-> List setApplicationLinks(ignore-setup-errors, ApplicationLinkModel)
+> List setApplicationLinks(request\_body)
 
 Set a list of application links
 
@@ -70,8 +70,7 @@ Set a list of application links
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
-| **ApplicationLinkModel** | [**List**](../Models/ApplicationLinkModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type
 

--- a/confluence/Apis/AuthenticationApi.md
+++ b/confluence/Apis/AuthenticationApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 
 <a name="setAuthenticationIdps"></a>
 # **setAuthenticationIdps**
-> List setAuthenticationIdps(AbstractAuthenticationIdpModel)
+> List setAuthenticationIdps(request\_body)
 
 Set all authentication identity providers
 
@@ -64,7 +64,7 @@ Set all authentication identity providers
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **AbstractAuthenticationIdpModel** | [**List**](../Models/AbstractAuthenticationIdpModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/AbstractAuthenticationIdpModel.md)|  | [optional] |
 
 ### Return type
 

--- a/confluence/Apis/DirectoriesApi.md
+++ b/confluence/Apis/DirectoriesApi.md
@@ -6,7 +6,7 @@ All URIs are relative to *https://CONFLUENCE_URL/rest/bootstrapi/1*
 |------------- | ------------- | -------------|
 | [**deleteDirectories**](DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 | [**getDirectories**](DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
-| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set directories mapped by their name. |
 
 
 <a name="deleteDirectories"></a>
@@ -38,7 +38,7 @@ null (empty response body)
 
 <a name="getDirectories"></a>
 # **getDirectories**
-> List getDirectories()
+> Map getDirectories()
 
 Get all user directories
 
@@ -47,7 +47,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**List**](../Models/AbstractDirectoryModel.md)
+[**Map**](../Models/AbstractDirectoryModel.md)
 
 ### Authorization
 
@@ -60,9 +60,9 @@ This endpoint does not need any parameter.
 
 <a name="setDirectories"></a>
 # **setDirectories**
-> List setDirectories(test-connection, AbstractDirectoryModel)
+> Map setDirectories(request\_body)
 
-Set a list of user directories
+Set directories mapped by their name.
 
     NOTE: All existing directories with the same &#39;name&#39; attribute are updated.
 
@@ -70,12 +70,11 @@ Set a list of user directories
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
-| **AbstractDirectoryModel** | [**List**](../Models/AbstractDirectoryModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type
 
-[**List**](../Models/AbstractDirectoryModel.md)
+[**Map**](../Models/AbstractDirectoryModel.md)
 
 ### Authorization
 

--- a/confluence/Apis/DirectoryApi.md
+++ b/confluence/Apis/DirectoryApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *https://CONFLUENCE_URL/rest/bootstrapi/1*
 
 <a name="createDirectory"></a>
 # **createDirectory**
-> AbstractDirectoryModel createDirectory(test-connection, AbstractDirectoryModel)
+> AbstractDirectoryModel createDirectory(AbstractDirectoryModel)
 
 Create a user directory
 
@@ -20,7 +20,6 @@ Create a user directory
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
 | **AbstractDirectoryModel** | [**AbstractDirectoryModel**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type
@@ -88,7 +87,7 @@ Get a user directory
 
 <a name="updateDirectory"></a>
 # **updateDirectory**
-> AbstractDirectoryModel updateDirectory(id, test-connection, AbstractDirectoryModel)
+> AbstractDirectoryModel updateDirectory(id, AbstractDirectoryModel)
 
 Update a user directory
 
@@ -97,7 +96,6 @@ Update a user directory
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **id** | **Long**|  | [default to null] |
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
 | **AbstractDirectoryModel** | [**AbstractDirectoryModel**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type

--- a/confluence/Models/AbstractDirectoryModel.md
+++ b/confluence/Models/AbstractDirectoryModel.md
@@ -4,19 +4,20 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 

--- a/confluence/Models/ApplicationLinkModel.md
+++ b/confluence/Models/ApplicationLinkModel.md
@@ -4,14 +4,15 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **uuid** | **UUID** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
-| **type** | **String** |  | [default to null] |
-| **displayUrl** | **URI** |  | [default to null] |
-| **rpcUrl** | **URI** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
+| **type** | **String** |  | [optional] [default to null] |
+| **displayUrl** | **URI** |  | [optional] [default to null] |
+| **rpcUrl** | **URI** |  | [optional] [default to null] |
 | **outgoingAuthType** | **String** |  | [optional] [default to null] |
 | **incomingAuthType** | **String** |  | [optional] [default to null] |
 | **primary** | **Boolean** |  | [optional] [default to null] |
 | **status** | **String** |  | [optional] [default to null] |
+| **ignoreSetupErrors** | **Boolean** |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/confluence/Models/DirectoryCrowdModel.md
+++ b/confluence/Models/DirectoryCrowdModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryCrowdServer**](DirectoryCrowdServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryCrowdPermissions**](DirectoryCrowdPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryCrowdAdvanced**](DirectoryCrowdAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/confluence/Models/DirectoryDelegatingModel.md
+++ b/confluence/Models/DirectoryDelegatingModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryPermissions**](DirectoryPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/confluence/Models/DirectoryGenericModel.md
+++ b/confluence/Models/DirectoryGenericModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/confluence/Models/DirectoryInternalModel.md
+++ b/confluence/Models/DirectoryInternalModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryPermissions**](DirectoryPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/confluence/Models/DirectoryLdapModel.md
+++ b/confluence/Models/DirectoryLdapModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/confluence/README.md
+++ b/confluence/README.md
@@ -24,7 +24,7 @@ All URIs are relative to *https://CONFLUENCE_URL/rest/bootstrapi/1*
 *CachesApi* | [**updateCache**](Apis/CachesApi.md#updateCache) | **PUT** /caches/{name} | Update an existing cache-size. Only Setting maxObjectCount is supported. |
 | *DirectoriesApi* | [**deleteDirectories**](Apis/DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 *DirectoriesApi* | [**getDirectories**](Apis/DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
-*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setDirectories) | **PUT** /directories | Set directories mapped by their name. |
 | *DirectoryApi* | [**createDirectory**](Apis/DirectoryApi.md#createDirectory) | **POST** /directory | Create a user directory |
 *DirectoryApi* | [**deleteDirectory**](Apis/DirectoryApi.md#deleteDirectory) | **DELETE** /directory/{id} | Delete a user directory |
 *DirectoryApi* | [**getDirectory**](Apis/DirectoryApi.md#getDirectory) | **GET** /directory/{id} | Get a user directory |

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/config/ServiceConfig.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/config/ServiceConfig.java
@@ -48,7 +48,7 @@ public class ServiceConfig {
 
     @Bean
     public DirectoriesService directoriesService() {
-        return new DirectoryServiceImpl(
+        return new DirectoriesServiceImpl(
                 atlassianConfig.crowdDirectoryService());
     }
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/AuthenticationServiceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/AuthenticationServiceImpl.java
@@ -11,8 +11,6 @@ import com.deftdevs.bootstrapi.confluence.model.util.AuthenticationIdpModelUtil;
 import com.deftdevs.bootstrapi.confluence.model.util.AuthenticationSsoModelUtil;
 import com.deftdevs.bootstrapi.confluence.service.api.ConfluenceAuthenticationService;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -32,21 +30,19 @@ public class AuthenticationServiceImpl implements ConfluenceAuthenticationServic
     }
 
     @Override
-    public List<AbstractAuthenticationIdpModel> getAuthenticationIdps() {
+    public Map<String, ? extends AbstractAuthenticationIdpModel> getAuthenticationIdps() {
         return idpConfigService.getIdpConfigs().stream()
                 .map(AuthenticationIdpModelUtil::toAuthenticationIdpModel)
-                .sorted(authenticationIdpModelComparator)
-                .collect(Collectors.toList());
+                .collect(Collectors.toMap(AbstractAuthenticationIdpModel::getName, Function.identity()));
     }
 
     @Override
-    public List<AbstractAuthenticationIdpModel> setAuthenticationIdps(
-            final List<AbstractAuthenticationIdpModel> authenticationIdpModels) {
+    public Map<String, ? extends AbstractAuthenticationIdpModel> setAuthenticationIdps(
+            final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModels) {
 
-        return authenticationIdpModels.stream()
+        return authenticationIdpModels.values().stream()
                 .map(this::setAuthenticationIdp)
-                .sorted(authenticationIdpModelComparator)
-                .collect(Collectors.toList());
+                .collect(Collectors.toMap(AbstractAuthenticationIdpModel::getName, Function.identity()));
     }
 
     public AbstractAuthenticationIdpModel setAuthenticationIdp(
@@ -92,7 +88,5 @@ public class AuthenticationServiceImpl implements ConfluenceAuthenticationServic
 
         return idpConfigsByName.get(name);
     }
-
-    static Comparator<AbstractAuthenticationIdpModel> authenticationIdpModelComparator = (a1, a2) -> a1.getName().compareToIgnoreCase(a2.getName());
 
 }

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/DirectoriesServiceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/DirectoriesServiceImpl.java
@@ -10,41 +10,36 @@ import com.deftdevs.bootstrapi.commons.exception.web.NotFoundException;
 import com.deftdevs.bootstrapi.commons.exception.web.ServiceUnavailableException;
 import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
 import com.deftdevs.bootstrapi.commons.model.DirectoryCrowdModel;
-import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
+import com.deftdevs.bootstrapi.commons.service.AbstractDirectoriesService;
 import com.deftdevs.bootstrapi.confluence.model.util.DirectoryModelUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-public class DirectoryServiceImpl implements DirectoriesService {
+public class DirectoriesServiceImpl extends AbstractDirectoriesService {
 
-    private static final Logger log = LoggerFactory.getLogger(DirectoryServiceImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(DirectoriesServiceImpl.class);
     public static final int RETRY_AFTER_IN_SECONDS = 5;
 
     private final CrowdDirectoryService crowdDirectoryService;
 
-    public DirectoryServiceImpl(
+    public DirectoriesServiceImpl(
             final CrowdDirectoryService crowdDirectoryService) {
 
         this.crowdDirectoryService = crowdDirectoryService;
     }
 
     @Override
-    public List<AbstractDirectoryModel> getDirectories() {
-        List<AbstractDirectoryModel> beans = new ArrayList<>();
-        for (Directory directory : crowdDirectoryService.findAllDirectories()) {
-            AbstractDirectoryModel crowdModel;
-            crowdModel = DirectoryModelUtil.toDirectoryModel(directory);
-            beans.add(crowdModel);
-        }
-        return beans;
+    public Map<String, AbstractDirectoryModel> getDirectories() {
+        return crowdDirectoryService.findAllDirectories().stream()
+                .map(DirectoryModelUtil::toDirectoryModel)
+                .collect(Collectors.toMap(AbstractDirectoryModel::getName, Function.identity()));
     }
 
     @Override
@@ -54,47 +49,23 @@ public class DirectoryServiceImpl implements DirectoriesService {
     }
 
     @Override
-    public List<AbstractDirectoryModel> setDirectories(List<AbstractDirectoryModel> directoryModels, boolean testConnection) {
-
-        final Map<String, Directory> existingDirectoriesByName = crowdDirectoryService.findAllDirectories().stream()
-                .collect(Collectors.toMap(Directory::getName, Function.identity()));
-
-        directoryModels.forEach(directoryRequestModel -> {
-            if (directoryRequestModel instanceof DirectoryCrowdModel) {
-                DirectoryCrowdModel crowdRequestModel = (DirectoryCrowdModel) directoryRequestModel;
-
-                if (existingDirectoriesByName.containsKey(crowdRequestModel.getName())) {
-                    setDirectory(existingDirectoriesByName.get(crowdRequestModel.getName()).getId(), crowdRequestModel, testConnection);
-                } else {
-                    addDirectory(crowdRequestModel, testConnection);
-                }
-            } else {
-                throw new BadRequestException(format("Updating directory type '%s' is not supported (yet)", directoryRequestModel.getClass()));
-            }
-        });
-        return getDirectories();
-    }
-
-    @Override
     public AbstractDirectoryModel setDirectory(
-            long id,
-            AbstractDirectoryModel abstractDirectoryModel,
-            boolean testConnection) {
+            final long id,
+            final AbstractDirectoryModel directoryModel) {
 
-        if (abstractDirectoryModel instanceof DirectoryCrowdModel) {
-            return setDirectoryCrowd(id, (DirectoryCrowdModel) abstractDirectoryModel, testConnection);
+        if (directoryModel instanceof DirectoryCrowdModel) {
+            return setDirectoryCrowd(id, (DirectoryCrowdModel) directoryModel);
         } else {
-            throw new BadRequestException(format("Setting directory type '%s' is not supported (yet)", abstractDirectoryModel.getClass()));
+            throw new BadRequestException(format("Setting directory type '%s' is not supported (yet)", directoryModel.getClass()));
         }
     }
 
     private AbstractDirectoryModel setDirectoryCrowd(
             long id,
-            DirectoryCrowdModel crowdModel,
-            boolean testConnection) {
+            DirectoryCrowdModel crowdModel) {
 
         Directory existingDirectory = findDirectory(id);
-        Directory directory = validateAndCreateDirectoryConfig(crowdModel, testConnection);
+        Directory directory = validateAndCreateDirectoryConfig(crowdModel);
 
         ImmutableDirectory.Builder directoryBuilder = ImmutableDirectory.newBuilder(existingDirectory);
 
@@ -118,16 +89,15 @@ public class DirectoryServiceImpl implements DirectoriesService {
 
     @Override
     public AbstractDirectoryModel addDirectory(
-            AbstractDirectoryModel abstractDirectoryModel,
-            boolean testConnection) {
+            AbstractDirectoryModel directoryModel) {
 
-        if (abstractDirectoryModel instanceof DirectoryCrowdModel) {
-            DirectoryCrowdModel crowdModel = (DirectoryCrowdModel) abstractDirectoryModel;
-            Directory directory = validateAndCreateDirectoryConfig(crowdModel, testConnection);
+        if (directoryModel instanceof DirectoryCrowdModel) {
+            DirectoryCrowdModel crowdModel = (DirectoryCrowdModel) directoryModel;
+            Directory directory = validateAndCreateDirectoryConfig(crowdModel);
             Directory addedDirectory = crowdDirectoryService.addDirectory(directory);
             return DirectoryModelUtil.toDirectoryModel(addedDirectory);
         } else {
-            throw new BadRequestException(format("Adding directory type '%s' is not supported (yet)", abstractDirectoryModel.getClass()));
+            throw new BadRequestException(format("Adding directory type '%s' is not supported (yet)", directoryModel.getClass()));
         }
     }
 
@@ -160,6 +130,11 @@ public class DirectoryServiceImpl implements DirectoriesService {
         }
     }
 
+    @Override
+    protected Set<Class<? extends AbstractDirectoryModel>> getSupportedClassesForUpdate() {
+        return Set.of(DirectoryCrowdModel.class);
+    }
+
     private Directory findDirectory(long id) {
         Directory directory = crowdDirectoryService.findDirectoryById(id);
         if (directory == null) {
@@ -168,14 +143,13 @@ public class DirectoryServiceImpl implements DirectoriesService {
         return directory;
     }
 
-    private Directory validateAndCreateDirectoryConfig(DirectoryCrowdModel crowdModel, boolean testConnection) {
+    private Directory validateAndCreateDirectoryConfig(DirectoryCrowdModel crowdModel) {
         Directory directory = DirectoryModelUtil.toDirectory(crowdModel);
         String directoryName = crowdModel.getName();
-        if (testConnection) {
+        if (Boolean.TRUE.equals(crowdModel.getTestConnection())) {
             log.debug("testing user directory connection for {}", directoryName);
             crowdDirectoryService.testConnection(directory);
         }
         return directory;
     }
-
 }

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/UsersServiceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/UsersServiceImpl.java
@@ -12,7 +12,7 @@ import com.deftdevs.bootstrapi.commons.model.UserModel;
 import com.deftdevs.bootstrapi.commons.service.api.UsersService;
 import com.deftdevs.bootstrapi.confluence.model.util.UserModelUtil;
 
-import java.util.List;
+import java.util.Map;
 
 import static com.deftdevs.bootstrapi.commons.util.ModelValidationUtil.validate;
 
@@ -96,10 +96,7 @@ public class UsersServiceImpl implements UsersService {
     }
 
     @Override
-    public List<UserModel> setUsers(
-            final long directoryId,
-            final List<UserModel> userModels) {
-
+    public Map<String, UserModel> setUsers(long directoryId, Map<String, UserModel> userModels) {
         // Not yet implemented
         throw new UnsupportedOperationException();
     }

--- a/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/AuthenticationServiceTest.java
+++ b/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/AuthenticationServiceTest.java
@@ -1,6 +1,10 @@
 package com.deftdevs.bootstrapi.confluence.service;
 
-import com.atlassian.plugins.authentication.api.config.*;
+import com.atlassian.plugins.authentication.api.config.IdpConfig;
+import com.atlassian.plugins.authentication.api.config.IdpConfigService;
+import com.atlassian.plugins.authentication.api.config.ImmutableSsoConfig;
+import com.atlassian.plugins.authentication.api.config.SsoConfig;
+import com.atlassian.plugins.authentication.api.config.SsoConfigService;
 import com.atlassian.plugins.authentication.api.config.oidc.OidcConfig;
 import com.atlassian.plugins.authentication.api.config.saml.SamlConfig;
 import com.deftdevs.bootstrapi.commons.exception.web.BadRequestException;
@@ -14,14 +18,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticationServiceTest {
@@ -45,10 +55,8 @@ class AuthenticationServiceTest {
         final SamlConfig samlConfig = SamlConfig.builder().setName("saml").build();
         doReturn(Arrays.asList(oidcConfig, samlConfig)).when(idpConfigService).getIdpConfigs();
 
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModels = authenticationService.getAuthenticationIdps();
-        final List<String> names = authenticationIdpModels.stream()
-                .map(AbstractAuthenticationIdpModel::getName)
-                .collect(Collectors.toList());
+        final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModels = authenticationService.getAuthenticationIdps();
+        final List<String> names = new ArrayList<>(authenticationIdpModels.keySet());
         assertTrue(names.contains(oidcConfig.getName()));
         assertTrue(names.contains(samlConfig.getName()));
     }
@@ -56,33 +64,40 @@ class AuthenticationServiceTest {
     @Test
     void testSetAuthenticationIdpsWithCreate() {
         final AuthenticationIdpOidcModel authenticationIdpOidcModel = AuthenticationIdpOidcModel.EXAMPLE_1;
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonList(authenticationIdpOidcModel);
+        final Map<String, AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonMap(
+                authenticationIdpOidcModel.getName(), authenticationIdpOidcModel);
         doAnswer(invocation -> invocation.getArgument(0)).when(idpConfigService).addIdpConfig(any());
 
-        final List<AbstractAuthenticationIdpModel> resultAuthenticationIdpModels = authenticationService.setAuthenticationIdps(authenticationIdpModels);
+        final Map<String, ? extends AbstractAuthenticationIdpModel> resultAuthenticationIdpModels = authenticationService.setAuthenticationIdps(authenticationIdpModels);
         verify(idpConfigService, times(1)).addIdpConfig(any());
-        assertEquals(authenticationIdpOidcModel.getId(), resultAuthenticationIdpModels.iterator().next().getId());
-        assertEquals(authenticationIdpOidcModel.getName(), resultAuthenticationIdpModels.iterator().next().getName());
+
+        final AbstractAuthenticationIdpModel resultAuthenticationIdpModel = resultAuthenticationIdpModels.values().iterator().next();
+        assertEquals(authenticationIdpOidcModel.getId(), resultAuthenticationIdpModel.getId());
+        assertEquals(authenticationIdpOidcModel.getName(), resultAuthenticationIdpModel.getName());
     }
 
     @Test
     void testSetAuthenticationIdpsWithUpdate() {
         final AuthenticationIdpOidcModel authenticationIdpOidcModel = AuthenticationIdpOidcModel.EXAMPLE_1;
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonList(authenticationIdpOidcModel);
+        final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonMap(
+                authenticationIdpOidcModel.getName(), authenticationIdpOidcModel);
         final IdpConfig idpConfig = AuthenticationIdpModelUtil.toIdpConfig(authenticationIdpOidcModel);
         doReturn(Collections.singletonList(idpConfig)).when(idpConfigService).getIdpConfigs();
         doAnswer(invocation -> invocation.getArgument(0)).when(idpConfigService).updateIdpConfig(any());
 
-        final List<AbstractAuthenticationIdpModel> resultAuthenticationIdpModels = authenticationService.setAuthenticationIdps(authenticationIdpModels);
+        final Map<String, ? extends AbstractAuthenticationIdpModel> resultAuthenticationIdpModels = authenticationService.setAuthenticationIdps(authenticationIdpModels);
         verify(idpConfigService, times(1)).updateIdpConfig(any());
-        assertEquals(authenticationIdpOidcModel.getId(), resultAuthenticationIdpModels.iterator().next().getId());
-        assertEquals(authenticationIdpOidcModel.getName(), resultAuthenticationIdpModels.iterator().next().getName());
+
+        final AbstractAuthenticationIdpModel resultAuthenticationIdpModel = resultAuthenticationIdpModels.values().iterator().next();
+        assertEquals(authenticationIdpOidcModel.getId(), resultAuthenticationIdpModel.getId());
+        assertEquals(authenticationIdpOidcModel.getName(), resultAuthenticationIdpModel.getName());
     }
 
     @Test
     void testSetAuthenticationIdpsNameNull() {
         final AuthenticationIdpOidcModel authenticationIdpOidcModel = AuthenticationIdpOidcModel.builder().build();
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonList(authenticationIdpOidcModel);
+        final Map<String, AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonMap(
+                authenticationIdpOidcModel.getName(), authenticationIdpOidcModel);
 
         assertThrows(BadRequestException.class, () -> {
             authenticationService.setAuthenticationIdps(authenticationIdpModels);
@@ -94,7 +109,8 @@ class AuthenticationServiceTest {
         final AuthenticationIdpOidcModel authenticationIdpOidcModel = AuthenticationIdpOidcModel.builder()
                 .name("")
                 .build();
-        final List<AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonList(authenticationIdpOidcModel);
+        final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModels = Collections.singletonMap(
+                authenticationIdpOidcModel.getName(), authenticationIdpOidcModel);
 
         assertThrows(BadRequestException.class, () -> {
             authenticationService.setAuthenticationIdps(authenticationIdpModels);

--- a/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/UserServiceTest.java
+++ b/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/UserServiceTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
+
 import static com.deftdevs.bootstrapi.confluence.model.util.UserModelUtil.toUser;
 import static com.deftdevs.bootstrapi.confluence.model.util.UserModelUtil.toUserModel;
 import static org.junit.jupiter.api.Assertions.*;
@@ -136,7 +138,7 @@ class UserServiceTest {
     @Test
     void testSetUsersByDirectoryIdNotImplemented() {
         assertThrows(UnsupportedOperationException.class, () -> {
-            userService.setUsers(0, null);
+            userService.setUsers(0, (Map<String, UserModel>) null);
         });
     }
 

--- a/crowd/Apis/ApplicationLinkApi.md
+++ b/crowd/Apis/ApplicationLinkApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *https://CROWD_URL/rest/bootstrapi/1*
 
 <a name="createApplicationLink"></a>
 # **createApplicationLink**
-> ApplicationLinkModel createApplicationLink(ignore-setup-errors, ApplicationLinkModel)
+> ApplicationLinkModel createApplicationLink(ApplicationLinkModel)
 
 Create an application link
 
@@ -20,7 +20,6 @@ Create an application link
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
 | **ApplicationLinkModel** | [**ApplicationLinkModel**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type
@@ -90,7 +89,7 @@ Get an application link
 
 <a name="updateApplicationLink"></a>
 # **updateApplicationLink**
-> ApplicationLinkModel updateApplicationLink(uuid, ignore-setup-errors, ApplicationLinkModel)
+> ApplicationLinkModel updateApplicationLink(uuid, ApplicationLinkModel)
 
 Update an application link
 
@@ -99,7 +98,6 @@ Update an application link
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **uuid** | **UUID**|  | [default to null] |
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
 | **ApplicationLinkModel** | [**ApplicationLinkModel**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type

--- a/crowd/Apis/ApplicationLinksApi.md
+++ b/crowd/Apis/ApplicationLinksApi.md
@@ -60,7 +60,7 @@ This endpoint does not need any parameter.
 
 <a name="setApplicationLinks"></a>
 # **setApplicationLinks**
-> List setApplicationLinks(ignore-setup-errors, ApplicationLinkModel)
+> List setApplicationLinks(request\_body)
 
 Set a list of application links
 
@@ -70,8 +70,7 @@ Set a list of application links
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
-| **ApplicationLinkModel** | [**List**](../Models/ApplicationLinkModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type
 

--- a/crowd/Apis/ApplicationsApi.md
+++ b/crowd/Apis/ApplicationsApi.md
@@ -62,7 +62,7 @@ This endpoint does not need any parameter.
 
 <a name="setApplications"></a>
 # **setApplications**
-> List setApplications(ApplicationModel)
+> List setApplications(request\_body)
 
 Set a list of applications
 
@@ -72,7 +72,7 @@ Set a list of applications
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **ApplicationModel** | [**List**](../Models/ApplicationModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/ApplicationModel.md)|  | [optional] |
 
 ### Return type
 

--- a/crowd/Apis/DirectoriesApi.md
+++ b/crowd/Apis/DirectoriesApi.md
@@ -6,7 +6,7 @@ All URIs are relative to *https://CROWD_URL/rest/bootstrapi/1*
 |------------- | ------------- | -------------|
 | [**deleteDirectories**](DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 | [**getDirectories**](DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
-| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set directories mapped by their name. |
 
 
 <a name="deleteDirectories"></a>
@@ -38,7 +38,7 @@ null (empty response body)
 
 <a name="getDirectories"></a>
 # **getDirectories**
-> List getDirectories()
+> Map getDirectories()
 
 Get all user directories
 
@@ -47,7 +47,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**List**](../Models/AbstractDirectoryModel.md)
+[**Map**](../Models/AbstractDirectoryModel.md)
 
 ### Authorization
 
@@ -60,9 +60,9 @@ This endpoint does not need any parameter.
 
 <a name="setDirectories"></a>
 # **setDirectories**
-> List setDirectories(test-connection, AbstractDirectoryModel)
+> Map setDirectories(request\_body)
 
-Set a list of user directories
+Set directories mapped by their name.
 
     NOTE: All existing directories with the same &#39;name&#39; attribute are updated.
 
@@ -70,12 +70,11 @@ Set a list of user directories
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
-| **AbstractDirectoryModel** | [**List**](../Models/AbstractDirectoryModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type
 
-[**List**](../Models/AbstractDirectoryModel.md)
+[**Map**](../Models/AbstractDirectoryModel.md)
 
 ### Authorization
 

--- a/crowd/Apis/DirectoryApi.md
+++ b/crowd/Apis/DirectoryApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *https://CROWD_URL/rest/bootstrapi/1*
 
 <a name="createDirectory"></a>
 # **createDirectory**
-> AbstractDirectoryModel createDirectory(test-connection, AbstractDirectoryModel)
+> AbstractDirectoryModel createDirectory(AbstractDirectoryModel)
 
 Create a user directory
 
@@ -20,7 +20,6 @@ Create a user directory
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
 | **AbstractDirectoryModel** | [**AbstractDirectoryModel**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type
@@ -88,7 +87,7 @@ Get a user directory
 
 <a name="updateDirectory"></a>
 # **updateDirectory**
-> AbstractDirectoryModel updateDirectory(id, test-connection, AbstractDirectoryModel)
+> AbstractDirectoryModel updateDirectory(id, AbstractDirectoryModel)
 
 Update a user directory
 
@@ -97,7 +96,6 @@ Update a user directory
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **id** | **Long**|  | [default to null] |
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
 | **AbstractDirectoryModel** | [**AbstractDirectoryModel**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type

--- a/crowd/Apis/GroupsApi.md
+++ b/crowd/Apis/GroupsApi.md
@@ -9,7 +9,7 @@ All URIs are relative to *https://CROWD_URL/rest/bootstrapi/1*
 
 <a name="setGroups"></a>
 # **setGroups**
-> GroupModel setGroups(directoryId, GroupModel)
+> GroupModel setGroups(directoryId, request\_body)
 
 Set groups
 
@@ -18,7 +18,7 @@ Set groups
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **directoryId** | **Long**|  | [optional] [default to null] |
-| **GroupModel** | [**List**](../Models/GroupModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/GroupModel.md)|  | [optional] |
 
 ### Return type
 

--- a/crowd/Models/AbstractDirectoryModel.md
+++ b/crowd/Models/AbstractDirectoryModel.md
@@ -4,19 +4,20 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 

--- a/crowd/Models/ApplicationLinkModel.md
+++ b/crowd/Models/ApplicationLinkModel.md
@@ -4,14 +4,15 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **uuid** | **UUID** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
-| **type** | **String** |  | [default to null] |
-| **displayUrl** | **URI** |  | [default to null] |
-| **rpcUrl** | **URI** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
+| **type** | **String** |  | [optional] [default to null] |
+| **displayUrl** | **URI** |  | [optional] [default to null] |
+| **rpcUrl** | **URI** |  | [optional] [default to null] |
 | **outgoingAuthType** | **String** |  | [optional] [default to null] |
 | **incomingAuthType** | **String** |  | [optional] [default to null] |
 | **primary** | **Boolean** |  | [optional] [default to null] |
 | **status** | **String** |  | [optional] [default to null] |
+| **ignoreSetupErrors** | **Boolean** |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/crowd/Models/DirectoryCrowdModel.md
+++ b/crowd/Models/DirectoryCrowdModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryCrowdServer**](DirectoryCrowdServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryCrowdPermissions**](DirectoryCrowdPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryCrowdAdvanced**](DirectoryCrowdAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/crowd/Models/DirectoryDelegatingModel.md
+++ b/crowd/Models/DirectoryDelegatingModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryPermissions**](DirectoryPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/crowd/Models/DirectoryGenericModel.md
+++ b/crowd/Models/DirectoryGenericModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/crowd/Models/DirectoryInternalModel.md
+++ b/crowd/Models/DirectoryInternalModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryPermissions**](DirectoryPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/crowd/Models/DirectoryLdapModel.md
+++ b/crowd/Models/DirectoryLdapModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/crowd/README.md
+++ b/crowd/README.md
@@ -23,7 +23,7 @@ All URIs are relative to *https://CROWD_URL/rest/bootstrapi/1*
 *ApplicationsApi* | [**setApplications**](Apis/ApplicationsApi.md#setApplications) | **PUT** /applications | Set a list of applications |
 | *DirectoriesApi* | [**deleteDirectories**](Apis/DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 *DirectoriesApi* | [**getDirectories**](Apis/DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
-*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setDirectories) | **PUT** /directories | Set directories mapped by their name. |
 | *DirectoryApi* | [**createDirectory**](Apis/DirectoryApi.md#createDirectory) | **POST** /directory | Create a user directory |
 *DirectoryApi* | [**deleteDirectory**](Apis/DirectoryApi.md#deleteDirectory) | **DELETE** /directory/{id} | Delete a user directory |
 *DirectoryApi* | [**getDirectory**](Apis/DirectoryApi.md#getDirectory) | **GET** /directory/{id} | Get a user directory |

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/util/DirectoryModelUtil.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/util/DirectoryModelUtil.java
@@ -23,13 +23,17 @@ import lombok.Getter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static com.deftdevs.bootstrapi.crowd.util.AttributeUtil.*;
+import static com.deftdevs.bootstrapi.crowd.util.AttributeUtil.fromBoolean;
+import static com.deftdevs.bootstrapi.crowd.util.AttributeUtil.fromIntegerCollection;
+import static com.deftdevs.bootstrapi.crowd.util.AttributeUtil.fromLong;
+import static com.deftdevs.bootstrapi.crowd.util.AttributeUtil.toBoolean;
+import static com.deftdevs.bootstrapi.crowd.util.AttributeUtil.toIntegerList;
+import static com.deftdevs.bootstrapi.crowd.util.AttributeUtil.toLong;
 import static java.lang.Boolean.TRUE;
 
 public class DirectoryModelUtil {
@@ -71,14 +75,10 @@ public class DirectoryModelUtil {
     static final String USER_USERNAME_KEY = "ldap.user.username";
     static final String USER_USERNAME_RDN_KEY = "ldap.user.username.rdn";
 
-    private static final Set<Class<? extends AbstractDirectoryModel>> SUPPORTED_DIRECTORY_BEAN_TYPES;
-
-    static {
-        final Set<Class<? extends AbstractDirectoryModel>> supportedDirectoryModelTypes = new HashSet<>();
-        supportedDirectoryModelTypes.add(DirectoryInternalModel.class);
-        supportedDirectoryModelTypes.add(DirectoryDelegatingModel.class);
-        SUPPORTED_DIRECTORY_BEAN_TYPES = Collections.unmodifiableSet(supportedDirectoryModelTypes);
-    }
+    public static final Set<Class<? extends AbstractDirectoryModel>> SUPPORTED_DIRECTORY_BEAN_TYPES = Set.of(
+            DirectoryInternalModel.class,
+            DirectoryDelegatingModel.class
+    );
 
     /*
      * Methods for converting directories to directory beans.

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationResourceImpl.java
@@ -8,7 +8,6 @@ import com.deftdevs.bootstrapi.crowd.service.api.ApplicationsService;
 
 import javax.inject.Inject;
 import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
 
 @SystemAdminOnly
 @Path(BootstrAPI.APPLICATION)
@@ -24,28 +23,32 @@ public class ApplicationResourceImpl implements ApplicationResource {
     }
 
     @Override
-    public Response getApplication(
+    public ApplicationModel getApplication(
             final long id) {
-        return Response.ok(applicationsService.getApplication(id)).build();
+
+        return applicationsService.getApplication(id);
     }
 
     @Override
-    public Response updateApplication(
+    public ApplicationModel updateApplication(
             final long id,
             final ApplicationModel applicationModel) {
-        return Response.ok(applicationsService.setApplication(id, applicationModel)).build();
+
+        return applicationsService.setApplication(id, applicationModel);
     }
 
     @Override
-    public Response createApplication(
+    public ApplicationModel createApplication(
             final ApplicationModel applicationModel) {
-        return Response.ok(applicationsService.addApplication(applicationModel)).build();
+
+        return applicationsService.addApplication(applicationModel);
     }
 
     @Override
-    public Response deleteApplication(long id) {
+    public void deleteApplication(
+            final long id) {
+
         applicationsService.deleteApplication(id);
-        return Response.ok().build();
     }
 
 }

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceImpl.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.Map;
 
 @SystemAdminOnly
 @Path(BootstrAPI.APPLICATIONS)
@@ -25,20 +26,22 @@ public class ApplicationsResourceImpl implements ApplicationsResource {
     }
 
     @Override
-    public Response getApplications() {
-        return Response.ok(applicationsService.getApplications()).build();
+    public Map<String, ApplicationModel> getApplications() {
+        return applicationsService.getApplications();
     }
 
     @Override
-    public Response setApplications(
-            final List<ApplicationModel> applicationModels) {
-        return Response.ok(applicationsService.setApplications(applicationModels)).build();
+    public Map<String, ApplicationModel> setApplications(
+            final Map<String, ApplicationModel> applicationModels) {
+
+        return applicationsService.setApplications(applicationModels);
     }
 
     @Override
-    public Response deleteApplications(boolean force) {
+    public void deleteApplications(
+            final boolean force) {
+
         applicationsService.deleteApplications(force);
-        return Response.ok().build();
     }
 
 }

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceImpl.java
@@ -9,7 +9,7 @@ import com.deftdevs.bootstrapi.crowd.service.api.GroupsService;
 import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
 @SystemAdminOnly
 @Path(BootstrAPI.GROUPS)
@@ -27,9 +27,9 @@ public class GroupsResourceImpl implements GroupsResource {
     @Override
     public Response setGroups(
             final long directoryId,
-            final List<GroupModel> groupModels) {
+            final Map<String, GroupModel> groupModels) {
 
-        final List<GroupModel> resultGroupModels = groupsService.setGroups(directoryId, groupModels);
+        final Map<String, GroupModel> resultGroupModels = groupsService.setGroups(directoryId, groupModels);
         return Response.ok(resultGroupModels).build();
     }
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationResource.java
@@ -9,9 +9,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 public interface ApplicationResource {
 
@@ -33,7 +39,7 @@ public interface ApplicationResource {
                     ),
             }
     )
-    Response getApplication(
+    ApplicationModel getApplication(
             @PathParam("id") long id);
 
     @POST
@@ -53,7 +59,7 @@ public interface ApplicationResource {
                     ),
             }
     )
-    Response createApplication(
+    ApplicationModel createApplication(
             ApplicationModel applicationModel);
 
     @PUT
@@ -74,9 +80,9 @@ public interface ApplicationResource {
                     ),
             }
     )
-    Response updateApplication(
+    ApplicationModel updateApplication(
             @PathParam("id") long id,
-            ApplicationModel applicationsModelModels);
+            ApplicationModel applicationModel);
 
     @DELETE
     @Path("{id}")
@@ -94,7 +100,7 @@ public interface ApplicationResource {
                     ),
             }
     )
-    Response deleteApplication(
+    void deleteApplication(
             @PathParam("id") final long id);
 
 }

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
@@ -9,10 +9,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
 public interface ApplicationsResource {
 
@@ -33,7 +37,7 @@ public interface ApplicationsResource {
                     ),
             }
     )
-    Response getApplications();
+    Map<String, ApplicationModel> getApplications();
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -53,8 +57,8 @@ public interface ApplicationsResource {
                     ),
             }
     )
-    Response setApplications(
-            List<ApplicationModel> applicationModels);
+    Map<String, ApplicationModel> setApplications(
+            Map<String, ApplicationModel> applicationModels);
 
     @DELETE
     @Operation(
@@ -72,7 +76,7 @@ public interface ApplicationsResource {
                     ),
             }
     )
-    Response deleteApplications(
+    void deleteApplications(
             @QueryParam("force") final boolean force);
 
 }

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupsResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupsResource.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.List;
+import java.util.Map;
 
 public interface GroupsResource {
 
@@ -34,6 +34,6 @@ public interface GroupsResource {
     )
     Response setGroups(
             @QueryParam("directoryId") final long directoryId,
-            final List<GroupModel> groupModels);
+            final Map<String, GroupModel> groupModels);
 
 }

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceImpl.java
@@ -17,8 +17,8 @@ import com.deftdevs.bootstrapi.crowd.service.api.GroupsService;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class GroupsServiceImpl implements GroupsService {
 
@@ -115,17 +115,20 @@ public class GroupsServiceImpl implements GroupsService {
     }
 
     @Override
-    public List<GroupModel> setGroups(
+    public Map<String, GroupModel> setGroups(
             final long directoryId,
-            final List<GroupModel> groupModels) {
+            final Map<String, GroupModel> groupModels) {
 
         if (groupModels == null) {
-            return Collections.emptyList();
+            return Collections.emptyMap();
         }
 
-        return groupModels.stream()
-                .map(groupModel -> setGroup(directoryId, groupModel.getName(), groupModel))
-                .collect(Collectors.toList());
+        final Map<String, GroupModel> resultGroupModels = new LinkedHashMap<>();
+        for (Map.Entry<String, GroupModel> entry : groupModels.entrySet()) {
+            final GroupModel resultGroupModel = setGroup(directoryId, entry.getKey(), entry.getValue());
+            resultGroupModels.put(resultGroupModel.getName(), resultGroupModel);
+        }
+        return resultGroupModels;
     }
 
     @Nullable

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceImpl.java
@@ -75,17 +75,20 @@ public class UsersServiceImpl implements UsersService {
     }
 
     @Override
-    public List<UserModel> setUsers(
+    public Map<String, UserModel> setUsers(
             final long directoryId,
-            final List<UserModel> userModels) {
+            final Map<String, UserModel> userModels) {
 
         if (userModels == null) {
-            return Collections.emptyList();
+            return Collections.emptyMap();
         }
 
-        return userModels.stream()
-                .map(userModel -> setUser(directoryId, userModel))
-                .collect(Collectors.toList());
+        final Map<String, UserModel> resultUserModels = new LinkedHashMap<>();
+        for (Map.Entry<String, UserModel> entry : userModels.entrySet()) {
+            final UserModel resultUserModel = setUser(directoryId, entry.getValue());
+            resultUserModels.put(resultUserModel.getUsername(), resultUserModel);
+        }
+        return resultUserModels;
     }
 
     public UserModel addUser(

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/api/ApplicationsService.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/api/ApplicationsService.java
@@ -2,17 +2,17 @@ package com.deftdevs.bootstrapi.crowd.service.api;
 
 import com.deftdevs.bootstrapi.crowd.model.ApplicationModel;
 
-import java.util.List;
+import java.util.Map;
 
 public interface ApplicationsService {
 
-    List<ApplicationModel> getApplications();
+    Map<String, ApplicationModel> getApplications();
 
     ApplicationModel getApplication(
             long id);
 
-    List<ApplicationModel> setApplications(
-            List<ApplicationModel> applicationModels);
+    Map<String, ApplicationModel> setApplications(
+            Map<String, ApplicationModel> applicationModels);
 
     ApplicationModel setApplication(
             long id,

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/api/GroupsService.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/api/GroupsService.java
@@ -2,7 +2,7 @@ package com.deftdevs.bootstrapi.crowd.service.api;
 
 import com.deftdevs.bootstrapi.commons.model.GroupModel;
 
-import java.util.List;
+import java.util.Map;
 
 public interface GroupsService {
 
@@ -61,8 +61,8 @@ public interface GroupsService {
      * @param groupModels the group beans
      * @return the set group beans
      */
-    List<GroupModel> setGroups(
+    Map<String, GroupModel> setGroups(
             final long directoryId,
-            final List<GroupModel> groupModels);
+            final Map<String, GroupModel> groupModels);
 
 }

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/config/TestConfig.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/config/TestConfig.java
@@ -1,0 +1,43 @@
+package com.deftdevs.bootstrapi.crowd.config;
+
+import com.atlassian.crowd.manager.application.ApplicationManager;
+import com.atlassian.crowd.manager.directory.DirectoryManager;
+import com.atlassian.crowd.manager.property.PropertyManager;
+import com.atlassian.crowd.manager.property.PropertyManagerException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.net.URI;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test configuration that provides mocked versions of OSGi services
+ * for unit and integration tests that don't need real OSGi services.
+ */
+@Configuration
+public class TestConfig {
+
+    @Bean
+    @Primary
+    public PropertyManager propertyManager() throws PropertyManagerException {
+        PropertyManager mock = mock(PropertyManager.class);
+        // Configure basic mock behavior
+        when(mock.getBaseUrl()).thenReturn(URI.create("http://localhost:8095/crowd"));
+        return mock;
+    }
+
+    @Bean
+    @Primary
+    public ApplicationManager applicationManager() {
+        return mock(ApplicationManager.class);
+    }
+
+    @Bean
+    @Primary
+    public DirectoryManager directoryManager() {
+        return mock(DirectoryManager.class);
+    }
+}

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
@@ -31,13 +31,13 @@ public class GroupsResourceTest {
 
     @Test
     public void testSetGroups() {
-        final List<GroupModel> groupModels = Collections.singletonList(GroupModel.EXAMPLE_1);
+        final Map<String, GroupModel> groupModels = Collections.singletonMap(GroupModel.EXAMPLE_1.getName(), GroupModel.EXAMPLE_1);
         doReturn(groupModels).when(groupsService).setGroups(anyLong(), any());
 
         final Response response = groupsResource.setGroups(0L, groupModels);
         assertEquals(200, response.getStatus());
 
-        final List<GroupModel> responseGroupModels = (List<GroupModel>) response.getEntity();
+        final Map<String, GroupModel> responseGroupModels = (Map<String, GroupModel>) response.getEntity();
         assertEquals(groupModels, responseGroupModels);
     }
 

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/ApplicationsServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/ApplicationsServiceTest.java
@@ -25,16 +25,27 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.deftdevs.bootstrapi.crowd.model.ApplicationModel.EXAMPLE_1;
 import static com.deftdevs.bootstrapi.crowd.model.ApplicationModel.EXAMPLE_2;
 import static com.deftdevs.bootstrapi.crowd.model.util.ApplicationModelUtil.toApplication;
 import static com.deftdevs.bootstrapi.crowd.model.util.ApplicationModelUtil.toStringCollection;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class ApplicationsServiceTest {
@@ -78,11 +89,11 @@ public class ApplicationsServiceTest {
         final List<Application> applications = Collections.singletonList(application);
         doReturn(applications).when(applicationManager).findAll();
 
-        final List<ApplicationModel> applicationModels = applicationsService.getApplications();
+        final Map<String, ApplicationModel> applicationModels = applicationsService.getApplications();
         assertNotNull(applicationModels);
         assertEquals(1, applicationModels.size());
 
-        final ApplicationModel resultApplicationModel = applicationModels.iterator().next();
+        final ApplicationModel resultApplicationModel = applicationModels.values().iterator().next();
         assertEquals(EXAMPLE_1.getName(), resultApplicationModel.getName());
         assertEquals(EXAMPLE_1.getDescription(), resultApplicationModel.getDescription());
         assertEquals(EXAMPLE_1.getActive(), resultApplicationModel.getActive());
@@ -191,7 +202,8 @@ public class ApplicationsServiceTest {
         final Application applicationExample1 = ImmutableApplication.builder(toApplication(EXAMPLE_1))
                 .setId(EXAMPLE_1.getId())
                 .build();
-        final List<ApplicationModel> applicationModels = Arrays.asList(EXAMPLE_1, EXAMPLE_2);
+        final Map<String, ApplicationModel> applicationModels = Stream.of(EXAMPLE_1, EXAMPLE_2)
+                .collect(Collectors.toMap(ApplicationModel::getName, Function.identity()));
         doReturn(applicationExample1).when(applicationManager).findByName(EXAMPLE_1.getName());
         doThrow(new ApplicationNotFoundException("")).when(applicationManager).findByName(EXAMPLE_2.getName());
 
@@ -199,7 +211,7 @@ public class ApplicationsServiceTest {
         doReturn(EXAMPLE_1).when(spy).setApplication(EXAMPLE_1.getId(), EXAMPLE_1);
         doReturn(EXAMPLE_2).when(spy).addApplication(EXAMPLE_2);
 
-        final List<ApplicationModel> responseApplicationModels = spy.setApplications(applicationModels);
+        final Map<String, ApplicationModel> responseApplicationModels = spy.setApplications(applicationModels);
         verify(spy).setApplication(EXAMPLE_1.getId(), EXAMPLE_1);
         verify(spy).addApplication(EXAMPLE_2);
         assertEquals(applicationModels.size(), responseApplicationModels.size());

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/DirectoriesServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/DirectoriesServiceTest.java
@@ -33,6 +33,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,12 +75,11 @@ public class DirectoriesServiceTest {
         doReturn(Collections.singletonList(directoryInternal)).when(spy).findAllDirectories();
 
         final AbstractDirectoryModel directoryModel = DirectoryModelUtil.toDirectoryModel(directoryInternalNew);
-        final List<AbstractDirectoryModel> directoryModels = Collections.singletonList(directoryModel);
-        final boolean testConnection = false;
-        doReturn(null).when(spy).addDirectory(directoryModel, testConnection);
+        final Map<String, AbstractDirectoryModel> directoryModels = Collections.singletonMap(directoryModel.getName(), directoryModel);
+        doReturn(directoryModel).when(spy).addDirectory(directoryModel);
 
-        spy.setDirectories(directoryModels, testConnection);
-        verify(spy).addDirectory(directoryModel, testConnection);
+        spy.setDirectories(directoryModels);
+        verify(spy).addDirectory(directoryModel);
     }
 
     @Test
@@ -90,11 +90,11 @@ public class DirectoriesServiceTest {
         doReturn(Collections.singletonList(directoryInternal)).when(spy).findAllDirectories();
 
         final AbstractDirectoryModel directoryModel = DirectoryModelUtil.toDirectoryModel(directoryAzureAd);
-        final List<AbstractDirectoryModel> directoryModels = Collections.singletonList(directoryModel);
+        final Map<String, AbstractDirectoryModel> directoryModels = Collections.singletonMap(directoryModel.getName(), directoryModel);
         final boolean testConnection = false;
 
         assertThrows(BadRequestException.class, () -> {
-            spy.setDirectories(directoryModels, testConnection);
+            spy.setDirectories(directoryModels);
         });
     }
 
@@ -105,12 +105,11 @@ public class DirectoriesServiceTest {
         doReturn(Collections.singletonList(directory)).when(spy).findAllDirectories();
 
         final AbstractDirectoryModel directoryModel = DirectoryModelUtil.toDirectoryModel(directory);
-        final List<AbstractDirectoryModel> directoryModels = Collections.singletonList(directoryModel);
-        final boolean testConnection = false;
-        doReturn(null).when(spy).setDirectory(directory.getId(), directoryModel, testConnection);
+        final Map<String, AbstractDirectoryModel> directoryModels = Collections.singletonMap(directoryModel.getName(), directoryModel);
+        doReturn(directoryModel).when(spy).setDirectory(directory.getId(), directoryModel);
 
-        spy.setDirectories(directoryModels, testConnection);
-        verify(spy).setDirectory(directory.getId(), directoryModel, testConnection);
+        spy.setDirectories(directoryModels);
+        verify(spy).setDirectory(directory.getId(), directoryModel);
     }
 
     @Test
@@ -118,15 +117,13 @@ public class DirectoriesServiceTest {
         final Directory directoryInternal = getTestDirectoryInternal();
         final Directory directoryAzureAd = getTestDirectoryAzureAd();
         final DirectoriesServiceImpl spy = spy(directoriesService);
-        doReturn(ListUtil.of(directoryInternal, directoryAzureAd)).when(spy).findAllDirectories();
-        doReturn(directoryAzureAd).when(spy).findDirectory(directoryAzureAd.getId());
+        doReturn(List.of(directoryInternal, directoryAzureAd)).when(spy).findAllDirectories();
 
         final AbstractDirectoryModel directoryModel = DirectoryModelUtil.toDirectoryModel(directoryAzureAd);
-        final List<AbstractDirectoryModel> directoryModels = Collections.singletonList(directoryModel);
-        final boolean testConnection = false;
+        final Map<String, AbstractDirectoryModel> directoryModels = Collections.singletonMap(directoryModel.getName(), directoryModel);
 
         assertThrows(BadRequestException.class, () -> {
-            spy.setDirectories(directoryModels, testConnection);
+            spy.setDirectories(directoryModels);
         });
     }
 
@@ -137,7 +134,7 @@ public class DirectoriesServiceTest {
         // Return the same directory as passed as argument
         doAnswer(invocation -> invocation.getArgument(0, Directory.class)).when(directoryManager).addDirectory(any());
 
-        directoriesService.addDirectory(directoryModel, false);
+        directoriesService.addDirectory(directoryModel);
         verify(directoryManager).addDirectory(any());
     }
 
@@ -148,20 +145,20 @@ public class DirectoriesServiceTest {
         assertEquals(DirectoryInternalModel.class, directoryModel.getClass());
 
         final DirectoryInternalModel directoryInternalModel = (DirectoryInternalModel) directoryModel;
-        directoryInternalModel.setGroups(Collections.singletonList(GroupModel.EXAMPLE_1));
-        directoryInternalModel.setUsers(Collections.singletonList(UserModel.EXAMPLE_1));
+        directoryInternalModel.setGroups(Collections.singletonMap(GroupModel.EXAMPLE_1.getName(), GroupModel.EXAMPLE_1));
+        directoryInternalModel.setUsers(Collections.singletonMap(UserModel.EXAMPLE_1.getUsername(), UserModel.EXAMPLE_1));
 
         // Return the same directory as passed as argument
         doAnswer(invocation -> invocation.getArgument(0, Directory.class)).when(directoryManager).addDirectory(any());
-        // Return the same groups bean as passed as argument
-        doAnswer(invocation -> invocation.getArgument(1, List.class)).when(groupsService).setGroups(anyLong(), any());
-        // Return the same user beans as passed as argument
-        doAnswer(invocation -> invocation.getArgument(1, Collection.class)).when(usersService).setUsers(anyLong(), any());
+        // Return the same groups as passed as argument
+        doAnswer(invocation -> invocation.getArgument(1, Map.class)).when(groupsService).setGroups(anyLong(), any());
+        // Return the same users as passed as argument
+        doAnswer(invocation -> invocation.getArgument(1, Map.class)).when(usersService).setUsers(anyLong(), anyMap());
 
-        directoriesService.addDirectory(directoryInternalModel, false);
+        directoriesService.addDirectory(directoryInternalModel);
         verify(directoryManager).addDirectory(any());
         verify(groupsService).setGroups(anyLong(), any());
-        verify(usersService).setUsers(anyLong(), any());
+        verify(usersService).setUsers(anyLong(), anyMap());
     }
 
     @Test
@@ -171,7 +168,7 @@ public class DirectoriesServiceTest {
         doThrow(new DirectoryInstantiationException()).when(directoryManager).addDirectory(any());
 
         assertThrows(InternalServerErrorException.class, () -> {
-            directoriesService.addDirectory(directoryModel, false);
+            directoriesService.addDirectory(directoryModel);
         });
     }
 
@@ -182,10 +179,9 @@ public class DirectoriesServiceTest {
 
         final AbstractDirectoryModel directoryModel = DirectoryModelUtil.toDirectoryModel(directory);
         // Return the same directory as passed as argument
-
         doAnswer(invocation -> invocation.getArgument(0, Directory.class)).when(directoryManager).updateDirectory(any());
 
-        directoriesService.setDirectory(directory.getId(), directoryModel, false);
+        directoriesService.setDirectory(directory.getId(), directoryModel);
         verify(directoryManager).updateDirectory(any());
     }
 
@@ -198,20 +194,20 @@ public class DirectoriesServiceTest {
         assertEquals(DirectoryInternalModel.class, directoryModel.getClass());
 
         final DirectoryInternalModel directoryInternalModel = (DirectoryInternalModel) directoryModel;
-        directoryInternalModel.setGroups(Collections.singletonList(GroupModel.EXAMPLE_1));
-        directoryInternalModel.setUsers(Collections.singletonList(UserModel.EXAMPLE_1));
+        directoryInternalModel.setGroups(Collections.singletonMap(GroupModel.EXAMPLE_1.getName(), GroupModel.EXAMPLE_1));
+        directoryInternalModel.setUsers(Collections.singletonMap(UserModel.EXAMPLE_1.getUsername(), UserModel.EXAMPLE_1));
 
         // Return the same directory as passed as argument
         doAnswer(invocation -> invocation.getArgument(0, Directory.class)).when(directoryManager).updateDirectory(any());
-        // Return the same groups bean as passed as argument
-        doAnswer(invocation -> invocation.getArgument(1, List.class)).when(groupsService).setGroups(anyLong(), any());
-        // Return the same user beans as passed as argument
-        doAnswer(invocation -> invocation.getArgument(1, Collection.class)).when(usersService).setUsers(anyLong(), any());
+        // Return the same groups as passed as argument
+        doAnswer(invocation -> invocation.getArgument(1, Map.class)).when(groupsService).setGroups(anyLong(), any());
+        // Return the same users as passed as argument
+        doAnswer(invocation -> invocation.getArgument(1, Map.class)).when(usersService).setUsers(anyLong(), anyMap());
 
-        directoriesService.setDirectory(directory.getId(), directoryInternalModel, false);
+        directoriesService.setDirectory(directory.getId(), directoryInternalModel);
         verify(directoryManager).updateDirectory(any());
         verify(groupsService).setGroups(anyLong(), any());
-        verify(usersService).setUsers(anyLong(), any());
+        verify(usersService).setUsers(anyLong(), anyMap());
     }
 
     @Test
@@ -221,7 +217,7 @@ public class DirectoriesServiceTest {
         doThrow(new DirectoryNotFoundException(directory.getName())).when(directoryManager).findDirectoryById(directory.getId());
 
         assertThrows(NotFoundException.class, () -> {
-            directoriesService.setDirectory(directory.getId(), directoryModel, false);
+            directoriesService.setDirectory(directory.getId(), directoryModel);
         });
     }
 
@@ -233,7 +229,7 @@ public class DirectoriesServiceTest {
         doThrow(new DirectoryNotFoundException(directory.getName())).when(directoryManager).updateDirectory(any());
 
         assertThrows(InternalServerErrorException.class, () -> {
-            directoriesService.setDirectory(directory.getId(), directoryModel, false);
+            directoriesService.setDirectory(directory.getId(), directoryModel);
         });
     }
 
@@ -253,7 +249,7 @@ public class DirectoriesServiceTest {
         final Directory directoryAzureAd = getTestDirectoryAzureAd();
         final Directory directoryInternalOther = getTestDirectoryInternalOther();
         final DirectoriesServiceImpl spy = spy(directoriesService);
-        doReturn(ListUtil.of(directoryInternal, directoryAzureAd, directoryInternalOther)).when(spy).findAllDirectories();
+        doReturn(List.of(directoryInternal, directoryAzureAd, directoryInternalOther)).when(spy).findAllDirectories();
 
         spy.deleteDirectories(true);
         verify(spy, never()).deleteDirectory(directoryInternal.getId());
@@ -271,7 +267,7 @@ public class DirectoriesServiceTest {
     @Test
     public void testDeleteDirectory() throws CrowdException {
         final Directory directory = getTestDirectoryAzureAd();
-        doReturn(ListUtil.of(getTestDirectoryInternal(), directory)).when(directoryManager).searchDirectories(any());
+        doReturn(List.of(getTestDirectoryInternal(), directory)).when(directoryManager).searchDirectories(any());
         doReturn(directory).when(directoryManager).findDirectoryById(directory.getId());
         directoriesService.deleteDirectory(directory.getId());
         verify(directoryManager).removeDirectory(directory);
@@ -291,7 +287,7 @@ public class DirectoriesServiceTest {
     @Test
     public void testDeleteDirectoryNotFoundAfterAlreadyFound() throws CrowdException {
         final Directory directory = getTestDirectoryInternal();
-        doReturn(ListUtil.of(directory, getTestDirectoryAzureAd())).when(directoryManager).searchDirectories(any());
+        doReturn(List.of(directory, getTestDirectoryAzureAd())).when(directoryManager).searchDirectories(any());
         doReturn(directory).when(directoryManager).findDirectoryById(directory.getId());
         doThrow(new DirectoryNotFoundException("Directory")).when(directoryManager).removeDirectory(directory);
 
@@ -303,7 +299,7 @@ public class DirectoriesServiceTest {
     @Test
     public void testDeleteDirectorySynchronizing() throws CrowdException {
         final Directory directory = getTestDirectoryInternal();
-        doReturn(ListUtil.of(directory, getTestDirectoryAzureAd())).when(directoryManager).searchDirectories(any());
+        doReturn(List.of(directory, getTestDirectoryAzureAd())).when(directoryManager).searchDirectories(any());
         doReturn(directory).when(directoryManager).findDirectoryById(directory.getId());
         doThrow(new DirectoryCurrentlySynchronisingException(1L)).when(directoryManager).removeDirectory(directory);
 
@@ -346,23 +342,13 @@ public class DirectoriesServiceTest {
     }
 
     private List<Directory> getTestDirectories() {
-        return ListUtil.of(getTestDirectoryInternal(), getTestDirectoryAzureAd(), getTestDirectoryInternalOther());
+        return List.of(getTestDirectoryInternal(), getTestDirectoryAzureAd(), getTestDirectoryInternalOther());
     }
 
     private Date toDate(
             final LocalDate localDate) {
 
         return Date.from(localDate.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
-    }
-
-    private static class ListUtil {
-
-        static <T> List<T> of(T... elements) {
-            List<T> list = new ArrayList<>();
-            Collections.addAll(list, elements);
-            return list;
-        }
-
     }
 
 }

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceTest.java
@@ -18,9 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.WebApplicationException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -179,9 +179,9 @@ public class GroupsServiceTest {
 
     @Test
     public void testSetGroups() {
-        final List<GroupModel> groupModels = new ArrayList<>();
-        groupModels.add(GroupModel.EXAMPLE_1);
-        groupModels.add(GroupModel.EXAMPLE_2);
+        final Map<String, GroupModel> groupModels = new LinkedHashMap<>();
+        groupModels.put(GroupModel.EXAMPLE_1.getName(), GroupModel.EXAMPLE_1);
+        groupModels.put(GroupModel.EXAMPLE_2.getName(), GroupModel.EXAMPLE_2);
 
         final GroupsServiceImpl spy = spy(groupsService);
         doAnswer(invocation -> invocation.getArguments()[2]).when(spy).setGroup(anyLong(), any(), any());
@@ -192,7 +192,7 @@ public class GroupsServiceTest {
 
     @Test
     public void testSetGroupsNull() {
-        assertEquals(Collections.emptyList(), groupsService.setGroups(0L, null));
+        assertEquals(Collections.emptyMap(), groupsService.setGroups(0L, null));
     }
 
     // We kind of need to test all the exceptions here, but it's also pointless to test

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceTest.java
@@ -128,9 +128,9 @@ public class UsersServiceTest {
         final UserModel userModel = UserModelUtil.toUserModel(user);
         userModel.setPassword("s3cr3t");
 
-        final List<UserModel> userModels = new ArrayList<>();
-        userModels.add(userModel);
-        userModels.add(UserModel.EXAMPLE_1);
+        final Map<String, UserModel> userModels = new LinkedHashMap<>();
+        userModels.put(userModel.getUsername(), userModel);
+        userModels.put(UserModel.EXAMPLE_1.getUsername(), UserModel.EXAMPLE_1);
         final UsersServiceImpl spy = spy(usersService);
         doAnswer(invocation -> invocation.getArguments()[1]).when(spy).setUser(anyLong(), any());
 
@@ -140,7 +140,7 @@ public class UsersServiceTest {
 
     @Test
     public void testSetUsersNull() {
-        assertEquals(Collections.emptyList(), usersService.setUsers(getTestDirectory().getId(), null));
+        assertEquals(Collections.emptyMap(), usersService.setUsers(getTestDirectory().getId(), (Map<String, UserModel>) null));
     }
 
     @Test

--- a/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/DirectoryResourceFuncTest.java
+++ b/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/DirectoryResourceFuncTest.java
@@ -50,7 +50,7 @@ public class DirectoryResourceFuncTest {
         // Delete
         final HttpResponse<String> deleteResponse = HttpRequestHelper.builder(BootstrAPI.DIRECTORY + "/" + createdDirectory.getId())
                 .request(HttpMethod.DELETE, null);
-        assertEquals(Response.Status.OK.getStatusCode(), deleteResponse.statusCode());
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), deleteResponse.statusCode());
 
         // Verify deleted
         final HttpResponse<String> getAfterDeleteResponse = HttpRequestHelper.builder(BootstrAPI.DIRECTORY + "/" + createdDirectory.getId())

--- a/jira/Apis/ApplicationLinkApi.md
+++ b/jira/Apis/ApplicationLinkApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *https://JIRA_URL/rest/bootstrapi/1*
 
 <a name="createApplicationLink"></a>
 # **createApplicationLink**
-> ApplicationLinkModel createApplicationLink(ignore-setup-errors, ApplicationLinkModel)
+> ApplicationLinkModel createApplicationLink(ApplicationLinkModel)
 
 Create an application link
 
@@ -20,7 +20,6 @@ Create an application link
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
 | **ApplicationLinkModel** | [**ApplicationLinkModel**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type
@@ -90,7 +89,7 @@ Get an application link
 
 <a name="updateApplicationLink"></a>
 # **updateApplicationLink**
-> ApplicationLinkModel updateApplicationLink(uuid, ignore-setup-errors, ApplicationLinkModel)
+> ApplicationLinkModel updateApplicationLink(uuid, ApplicationLinkModel)
 
 Update an application link
 
@@ -99,7 +98,6 @@ Update an application link
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **uuid** | **UUID**|  | [default to null] |
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
 | **ApplicationLinkModel** | [**ApplicationLinkModel**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type

--- a/jira/Apis/ApplicationLinksApi.md
+++ b/jira/Apis/ApplicationLinksApi.md
@@ -60,7 +60,7 @@ This endpoint does not need any parameter.
 
 <a name="setApplicationLinks"></a>
 # **setApplicationLinks**
-> List setApplicationLinks(ignore-setup-errors, ApplicationLinkModel)
+> List setApplicationLinks(request\_body)
 
 Set a list of application links
 
@@ -70,8 +70,7 @@ Set a list of application links
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **ignore-setup-errors** | **Boolean**|  | [optional] [default to false] |
-| **ApplicationLinkModel** | [**List**](../Models/ApplicationLinkModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/ApplicationLinkModel.md)|  | [optional] |
 
 ### Return type
 

--- a/jira/Apis/AuthenticationApi.md
+++ b/jira/Apis/AuthenticationApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 
 <a name="setAuthenticationIdps"></a>
 # **setAuthenticationIdps**
-> List setAuthenticationIdps(AbstractAuthenticationIdpModel)
+> List setAuthenticationIdps(request\_body)
 
 Set all authentication identity providers
 
@@ -64,7 +64,7 @@ Set all authentication identity providers
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **AbstractAuthenticationIdpModel** | [**List**](../Models/AbstractAuthenticationIdpModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/AbstractAuthenticationIdpModel.md)|  | [optional] |
 
 ### Return type
 

--- a/jira/Apis/DirectoriesApi.md
+++ b/jira/Apis/DirectoriesApi.md
@@ -6,7 +6,7 @@ All URIs are relative to *https://JIRA_URL/rest/bootstrapi/1*
 |------------- | ------------- | -------------|
 | [**deleteDirectories**](DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 | [**getDirectories**](DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
-| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+| [**setDirectories**](DirectoriesApi.md#setDirectories) | **PUT** /directories | Set directories mapped by their name. |
 
 
 <a name="deleteDirectories"></a>
@@ -38,7 +38,7 @@ null (empty response body)
 
 <a name="getDirectories"></a>
 # **getDirectories**
-> List getDirectories()
+> Map getDirectories()
 
 Get all user directories
 
@@ -47,7 +47,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**List**](../Models/AbstractDirectoryModel.md)
+[**Map**](../Models/AbstractDirectoryModel.md)
 
 ### Authorization
 
@@ -60,9 +60,9 @@ This endpoint does not need any parameter.
 
 <a name="setDirectories"></a>
 # **setDirectories**
-> List setDirectories(test-connection, AbstractDirectoryModel)
+> Map setDirectories(request\_body)
 
-Set a list of user directories
+Set directories mapped by their name.
 
     NOTE: All existing directories with the same &#39;name&#39; attribute are updated.
 
@@ -70,12 +70,11 @@ Set a list of user directories
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
-| **AbstractDirectoryModel** | [**List**](../Models/AbstractDirectoryModel.md)|  | [optional] |
+| **request\_body** | [**Map**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type
 
-[**List**](../Models/AbstractDirectoryModel.md)
+[**Map**](../Models/AbstractDirectoryModel.md)
 
 ### Authorization
 

--- a/jira/Apis/DirectoryApi.md
+++ b/jira/Apis/DirectoryApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *https://JIRA_URL/rest/bootstrapi/1*
 
 <a name="createDirectory"></a>
 # **createDirectory**
-> AbstractDirectoryModel createDirectory(test-connection, AbstractDirectoryModel)
+> AbstractDirectoryModel createDirectory(AbstractDirectoryModel)
 
 Create a user directory
 
@@ -20,7 +20,6 @@ Create a user directory
 
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
 | **AbstractDirectoryModel** | [**AbstractDirectoryModel**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type
@@ -88,7 +87,7 @@ Get a user directory
 
 <a name="updateDirectory"></a>
 # **updateDirectory**
-> AbstractDirectoryModel updateDirectory(id, test-connection, AbstractDirectoryModel)
+> AbstractDirectoryModel updateDirectory(id, AbstractDirectoryModel)
 
 Update a user directory
 
@@ -97,7 +96,6 @@ Update a user directory
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **id** | **Long**|  | [default to null] |
-| **test-connection** | **Boolean**|  | [optional] [default to false] |
 | **AbstractDirectoryModel** | [**AbstractDirectoryModel**](../Models/AbstractDirectoryModel.md)|  | [optional] |
 
 ### Return type

--- a/jira/Models/AbstractDirectoryModel.md
+++ b/jira/Models/AbstractDirectoryModel.md
@@ -4,19 +4,20 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 

--- a/jira/Models/ApplicationLinkModel.md
+++ b/jira/Models/ApplicationLinkModel.md
@@ -4,14 +4,15 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **uuid** | **UUID** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
-| **type** | **String** |  | [default to null] |
-| **displayUrl** | **URI** |  | [default to null] |
-| **rpcUrl** | **URI** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
+| **type** | **String** |  | [optional] [default to null] |
+| **displayUrl** | **URI** |  | [optional] [default to null] |
+| **rpcUrl** | **URI** |  | [optional] [default to null] |
 | **outgoingAuthType** | **String** |  | [optional] [default to null] |
 | **incomingAuthType** | **String** |  | [optional] [default to null] |
 | **primary** | **Boolean** |  | [optional] [default to null] |
 | **status** | **String** |  | [optional] [default to null] |
+| **ignoreSetupErrors** | **Boolean** |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/jira/Models/DirectoryCrowdModel.md
+++ b/jira/Models/DirectoryCrowdModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryCrowdServer**](DirectoryCrowdServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryCrowdPermissions**](DirectoryCrowdPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryCrowdAdvanced**](DirectoryCrowdAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/jira/Models/DirectoryDelegatingModel.md
+++ b/jira/Models/DirectoryDelegatingModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryPermissions**](DirectoryPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/jira/Models/DirectoryGenericModel.md
+++ b/jira/Models/DirectoryGenericModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/jira/Models/DirectoryInternalModel.md
+++ b/jira/Models/DirectoryInternalModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryPermissions**](DirectoryPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/jira/Models/DirectoryLdapModel.md
+++ b/jira/Models/DirectoryLdapModel.md
@@ -4,20 +4,21 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 | **id** | **Long** |  | [optional] [default to null] |
-| **name** | **String** |  | [default to null] |
+| **name** | **String** |  | [optional] [default to null] |
 | **description** | **String** |  | [optional] [default to null] |
 | **active** | **Boolean** |  | [optional] [default to null] |
 | **createdDate** | **Date** |  | [optional] [default to null] |
 | **updatedDate** | **Date** |  | [optional] [default to null] |
 | **type** | **String** |  | [default to null] |
+| **testConnection** | **Boolean** |  | [optional] [default to null] |
 | **server** | [**DirectoryLdapServer**](DirectoryLdapServer.md) |  | [optional] [default to null] |
 | **permissions** | [**DirectoryLdapPermissions**](DirectoryLdapPermissions.md) |  | [optional] [default to null] |
 | **advanced** | [**DirectoryInternalAdvanced**](DirectoryInternalAdvanced.md) |  | [optional] [default to null] |
 | **connector** | [**DirectoryDelegatingConnector**](DirectoryDelegatingConnector.md) |  | [optional] [default to null] |
 | **configuration** | [**DirectoryDelegatingConfiguration**](DirectoryDelegatingConfiguration.md) |  | [optional] [default to null] |
 | **credentialPolicy** | [**DirectoryInternalCredentialPolicy**](DirectoryInternalCredentialPolicy.md) |  | [optional] [default to null] |
-| **groups** | [**List**](GroupModel.md) |  | [optional] [default to null] |
-| **users** | [**List**](UserModel.md) |  | [optional] [default to null] |
+| **groups** | [**Map**](GroupModel.md) |  | [optional] [default to null] |
+| **users** | [**Map**](UserModel.md) |  | [optional] [default to null] |
 | **schema** | [**DirectoryLdapSchema**](DirectoryLdapSchema.md) |  | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/jira/README.md
+++ b/jira/README.md
@@ -20,7 +20,7 @@ All URIs are relative to *https://JIRA_URL/rest/bootstrapi/1*
 *AuthenticationApi* | [**setAuthenticationSso**](Apis/AuthenticationApi.md#setAuthenticationSso) | **PATCH** /authentication/sso | Set authentication SSO configuration |
 | *DirectoriesApi* | [**deleteDirectories**](Apis/DirectoriesApi.md#deleteDirectories) | **DELETE** /directories | Delete all user directories |
 *DirectoriesApi* | [**getDirectories**](Apis/DirectoriesApi.md#getDirectories) | **GET** /directories | Get all user directories |
-*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setDirectories) | **PUT** /directories | Set a list of user directories |
+*DirectoriesApi* | [**setDirectories**](Apis/DirectoriesApi.md#setDirectories) | **PUT** /directories | Set directories mapped by their name. |
 | *DirectoryApi* | [**createDirectory**](Apis/DirectoryApi.md#createDirectory) | **POST** /directory | Create a user directory |
 *DirectoryApi* | [**deleteDirectory**](Apis/DirectoryApi.md#deleteDirectory) | **DELETE** /directory/{id} | Delete a user directory |
 *DirectoryApi* | [**getDirectory**](Apis/DirectoryApi.md#getDirectory) | **GET** /directory/{id} | Get a user directory |

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/config/ServiceConfig.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/config/ServiceConfig.java
@@ -28,7 +28,7 @@ public class ServiceConfig {
 
     @Bean
     public DirectoriesService directoriesService() {
-        return new DirectoryServiceImpl(
+        return new DirectoriesServiceImpl(
                 atlassianConfig.crowdDirectoryService());
     }
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/AuthenticationServiceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/AuthenticationServiceImpl.java
@@ -11,8 +11,6 @@ import com.deftdevs.bootstrapi.jira.model.util.AuthenticationIdpModelUtil;
 import com.deftdevs.bootstrapi.jira.model.util.AuthenticationSsoModelUtil;
 import com.deftdevs.bootstrapi.jira.service.api.JiraAuthenticationService;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -31,21 +29,19 @@ public class AuthenticationServiceImpl implements JiraAuthenticationService {
     }
 
     @Override
-    public List<AbstractAuthenticationIdpModel> getAuthenticationIdps() {
+    public Map<String, ? extends AbstractAuthenticationIdpModel> getAuthenticationIdps() {
         return idpConfigService.getIdpConfigs().stream()
                 .map(AuthenticationIdpModelUtil::toAuthenticationIdpModel)
-                .sorted(authenticationIdpModelComparator)
-                .collect(Collectors.toList());
+                .collect(Collectors.toMap(AbstractAuthenticationIdpModel::getName, Function.identity()));
     }
 
     @Override
-    public List<AbstractAuthenticationIdpModel> setAuthenticationIdps(
-            final List<AbstractAuthenticationIdpModel> authenticationIdpModels) {
+    public Map<String, ? extends AbstractAuthenticationIdpModel> setAuthenticationIdps(
+            final Map<String, ? extends AbstractAuthenticationIdpModel> authenticationIdpModels) {
 
-        return authenticationIdpModels.stream()
+        return authenticationIdpModels.values().stream()
                 .map(this::setAuthenticationIdp)
-                .sorted(authenticationIdpModelComparator)
-                .collect(Collectors.toList());
+                .collect(Collectors.toMap(AbstractAuthenticationIdpModel::getName, Function.identity()));
     }
 
     public AbstractAuthenticationIdpModel setAuthenticationIdp(
@@ -91,7 +87,5 @@ public class AuthenticationServiceImpl implements JiraAuthenticationService {
 
         return idpConfigsByName.get(name);
     }
-
-    static Comparator<AbstractAuthenticationIdpModel> authenticationIdpModelComparator = (a1, a2) -> a1.getName().compareToIgnoreCase(a2.getName());
 
 }

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/DirectoriesServiceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/DirectoriesServiceImpl.java
@@ -10,41 +10,36 @@ import com.deftdevs.bootstrapi.commons.exception.web.NotFoundException;
 import com.deftdevs.bootstrapi.commons.exception.web.ServiceUnavailableException;
 import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
 import com.deftdevs.bootstrapi.commons.model.DirectoryCrowdModel;
-import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
+import com.deftdevs.bootstrapi.commons.service.AbstractDirectoriesService;
 import com.deftdevs.bootstrapi.jira.model.util.DirectoryModelUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
-public class DirectoryServiceImpl implements DirectoriesService {
+public class DirectoriesServiceImpl extends AbstractDirectoriesService {
 
-    private static final Logger log = LoggerFactory.getLogger(DirectoryServiceImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(DirectoriesServiceImpl.class);
     public static final int RETRY_AFTER_IN_SECONDS = 5;
 
     private final CrowdDirectoryService crowdDirectoryService;
 
-    public DirectoryServiceImpl(
+    public DirectoriesServiceImpl(
             final CrowdDirectoryService crowdDirectoryService) {
 
         this.crowdDirectoryService = crowdDirectoryService;
     }
 
     @Override
-    public List<AbstractDirectoryModel> getDirectories() {
-        List<AbstractDirectoryModel> beans = new ArrayList<>();
-        for (Directory directory : crowdDirectoryService.findAllDirectories()) {
-            AbstractDirectoryModel crowdModel;
-            crowdModel = DirectoryModelUtil.toDirectoryModel(directory);
-            beans.add(crowdModel);
-        }
-        return beans;
+    public Map<String, AbstractDirectoryModel> getDirectories() {
+        return crowdDirectoryService.findAllDirectories().stream()
+                .map(DirectoryModelUtil::toDirectoryModel)
+                .collect(Collectors.toMap(AbstractDirectoryModel::getName, Function.identity()));
     }
 
     @Override
@@ -54,41 +49,27 @@ public class DirectoryServiceImpl implements DirectoriesService {
     }
 
     @Override
-    public List<AbstractDirectoryModel> setDirectories(
-            List<AbstractDirectoryModel> directoryModels, boolean testConnection) {
-
-        final Map<String, Directory> existingDirectoriesByName = crowdDirectoryService.findAllDirectories().stream()
-                .collect(Collectors.toMap(Directory::getName, Function.identity()));
-
-        for (AbstractDirectoryModel directoryRequestModel : directoryModels) {
-            if (directoryRequestModel instanceof DirectoryCrowdModel) {
-                DirectoryCrowdModel crowdRequestModel = (DirectoryCrowdModel) directoryRequestModel;
-
-                if (existingDirectoriesByName.containsKey(crowdRequestModel.getName())) {
-                    setDirectory(existingDirectoriesByName.get(crowdRequestModel.getName()).getId(), crowdRequestModel, testConnection);
-                } else {
-                    addDirectory(crowdRequestModel, testConnection);
-                }
-            } else {
-                throw new BadRequestException(format("Updating directory type '%s' is not supported (yet)", directoryRequestModel.getClass()));
-            }
+    public AbstractDirectoryModel setDirectory(
+            final long id,
+            final AbstractDirectoryModel directoryModel) {
+        if (directoryModel instanceof DirectoryCrowdModel) {
+            return setDirectoryCrowd(id, (DirectoryCrowdModel) directoryModel);
+        } else {
+            throw new BadRequestException(format("Setting directory type '%s' is not supported (yet)", directoryModel.getClass()));
         }
-
-        return getDirectories();
     }
 
     @Override
-    public AbstractDirectoryModel setDirectory(long id, AbstractDirectoryModel abstractDirectoryModel, boolean testConnection) {
-        if (abstractDirectoryModel instanceof DirectoryCrowdModel) {
-            return setDirectoryCrowd(id, (DirectoryCrowdModel) abstractDirectoryModel, testConnection);
-        } else {
-            throw new BadRequestException(format("Setting directory type '%s' is not supported (yet)", abstractDirectoryModel.getClass()));
-        }
+    protected Set<Class<? extends AbstractDirectoryModel>> getSupportedClassesForUpdate() {
+        return Set.of(DirectoryCrowdModel.class);
     }
 
-    private AbstractDirectoryModel setDirectoryCrowd(long id, DirectoryCrowdModel crowdModel, boolean testConnection) {
+    private AbstractDirectoryModel setDirectoryCrowd(
+            final long id,
+            final DirectoryCrowdModel crowdModel) {
+
         Directory existingDirectory = findDirectory(id);
-        Directory directory = validateAndCreateDirectoryConfig(crowdModel, testConnection);
+        Directory directory = validateAndCreateDirectoryConfig(crowdModel);
 
         ImmutableDirectory.Builder directoryBuilder = ImmutableDirectory.newBuilder(existingDirectory);
 
@@ -113,19 +94,23 @@ public class DirectoryServiceImpl implements DirectoriesService {
     }
 
     @Override
-    public AbstractDirectoryModel addDirectory(AbstractDirectoryModel abstractDirectoryModel, boolean testConnection) {
-        if (abstractDirectoryModel instanceof DirectoryCrowdModel) {
-            DirectoryCrowdModel crowdModel = (DirectoryCrowdModel) abstractDirectoryModel;
-            Directory directory = validateAndCreateDirectoryConfig(crowdModel, testConnection);
+    public AbstractDirectoryModel addDirectory(
+            final AbstractDirectoryModel directoryModel) {
+
+        if (directoryModel instanceof DirectoryCrowdModel) {
+            DirectoryCrowdModel crowdModel = (DirectoryCrowdModel) directoryModel;
+            Directory directory = validateAndCreateDirectoryConfig(crowdModel);
             Directory addedDirectory = crowdDirectoryService.addDirectory(directory);
             return DirectoryModelUtil.toDirectoryModel(addedDirectory);
         } else {
-            throw new BadRequestException(format("Adding directory type '%s' is not supported (yet)", abstractDirectoryModel.getClass()));
+            throw new BadRequestException(format("Adding directory type '%s' is not supported (yet)", directoryModel.getClass()));
         }
     }
 
     @Override
-    public void deleteDirectories(boolean force) {
+    public void deleteDirectories(
+            final boolean force) {
+
         if (!force) {
             throw new BadRequestException("'force = true' must be supplied to delete all entries");
         } else {
@@ -140,7 +125,8 @@ public class DirectoryServiceImpl implements DirectoriesService {
     }
 
     @Override
-    public void deleteDirectory(long id) {
+    public void deleteDirectory(
+            final long id) {
 
         //ensure the directory exists
         findDirectory(id);
@@ -153,7 +139,9 @@ public class DirectoryServiceImpl implements DirectoriesService {
         }
     }
 
-    private Directory findDirectory(long id) {
+    private Directory findDirectory(
+            final long id) {
+
         Directory directory = crowdDirectoryService.findDirectoryById(id);
         if (directory == null) {
             throw new NotFoundException(String.format("directory with id '%s' was not found!", id));
@@ -161,13 +149,17 @@ public class DirectoryServiceImpl implements DirectoriesService {
         return directory;
     }
 
-    private Directory validateAndCreateDirectoryConfig(DirectoryCrowdModel crowdModel, boolean testConnection) {
+    private Directory validateAndCreateDirectoryConfig(
+            final DirectoryCrowdModel crowdModel) {
+
         Directory directory = DirectoryModelUtil.toDirectory(crowdModel);
         String directoryName = crowdModel.getName();
-        if (testConnection) {
+
+        if (Boolean.TRUE.equals(crowdModel.getTestConnection())) {
             log.debug("testing user directory connection for {}", directoryName);
             crowdDirectoryService.testConnection(directory);
         }
+
         return directory;
     }
 

--- a/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/DirectoryServiceTest.java
+++ b/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/DirectoryServiceTest.java
@@ -35,11 +35,11 @@ class DirectoryServiceTest {
     @Mock
     private CrowdDirectoryService crowdDirectoryService;
 
-    private DirectoryServiceImpl directoryService;
+    private DirectoriesServiceImpl directoryService;
 
     @BeforeEach
     public void setup() {
-        directoryService = new DirectoryServiceImpl(crowdDirectoryService);
+        directoryService = new DirectoriesServiceImpl(crowdDirectoryService);
     }
 
     @Test
@@ -47,8 +47,8 @@ class DirectoryServiceTest {
         final Directory directory = createDirectory();
         doReturn(Collections.singletonList(directory)).when(crowdDirectoryService).findAllDirectories();
 
-        final List<AbstractDirectoryModel> directories = directoryService.getDirectories();
-        assertEquals(directories.iterator().next(), DirectoryModelUtil.toDirectoryModel(directory));
+        final Map<String, AbstractDirectoryModel> directories = directoryService.getDirectories();
+        assertEquals(directories.values().iterator().next(), DirectoryModelUtil.toDirectoryModel(directory));
     }
 
     @Test
@@ -86,7 +86,7 @@ class DirectoryServiceTest {
 
         final DirectoryCrowdModel directoryModel = (DirectoryCrowdModel) DirectoryModelUtil.toDirectoryModel(directory);
         directoryModel.getServer().setAppPassword("test");
-        directoryService.setDirectories(Collections.singletonList(directoryModel), false);
+        directoryService.setDirectories(Collections.singletonMap(directoryModel.getName(), directoryModel));
         assertTrue(true, "Update Successful");
     }
 
@@ -99,8 +99,8 @@ class DirectoryServiceTest {
 
         final DirectoryCrowdModel directoryModel = (DirectoryCrowdModel) DirectoryModelUtil.toDirectoryModel(directory);
         directoryModel.getServer().setAppPassword("test");
-        final List<AbstractDirectoryModel> directoryAdded = directoryService.setDirectories(Collections.singletonList(directoryModel), false);
-        assertEquals(directoryAdded.iterator().next().getName(), directoryModel.getName());
+        final Map<String, ? extends AbstractDirectoryModel> directoryAdded = directoryService.setDirectories(Collections.singletonMap(directoryModel.getName(), directoryModel));
+        assertEquals(directoryAdded.values().iterator().next().getName(), directoryModel.getName());
     }
 
     @Test
@@ -112,8 +112,8 @@ class DirectoryServiceTest {
 
         final DirectoryCrowdModel directoryModel = (DirectoryCrowdModel) DirectoryModelUtil.toDirectoryModel(directory);
         directoryModel.getServer().setAppPassword("test");
-        final List<AbstractDirectoryModel> directoryAdded = directoryService.setDirectories(Collections.singletonList(directoryModel), true);
-        assertEquals(directoryAdded.iterator().next().getName(), directoryModel.getName());
+        final Map<String, ? extends AbstractDirectoryModel> directoryAdded = directoryService.setDirectories(Collections.singletonMap(directoryModel.getName(), directoryModel));
+        assertEquals(directoryAdded.values().iterator().next().getName(), directoryModel.getName());
     }
 
     @Test
@@ -128,7 +128,7 @@ class DirectoryServiceTest {
         directoryModel.setName(null);
 
         directoryModel.getServer().setAppPassword("test");
-        AbstractDirectoryModel directoryAdded = directoryService.setDirectory(1L, directoryModel, true);
+        AbstractDirectoryModel directoryAdded = directoryService.setDirectory(1L, directoryModel);
 
         assertEquals(directoryModel.getDescription(), directoryAdded.getDescription());
         assertEquals(directory.getName(), directoryAdded.getName());
@@ -143,7 +143,7 @@ class DirectoryServiceTest {
 
         DirectoryCrowdModel directoryModel = (DirectoryCrowdModel) DirectoryModelUtil.toDirectoryModel(directory);
         directoryModel.getServer().setAppPassword("test");
-        AbstractDirectoryModel directoryAdded = directoryService.setDirectory(1L, directoryModel, true);
+        AbstractDirectoryModel directoryAdded = directoryService.setDirectory(1L, directoryModel);
 
         assertEquals(directoryModel.getName(), directoryAdded.getName());
         assertEquals(directoryModel.getId(), directoryAdded.getId());
@@ -154,7 +154,7 @@ class DirectoryServiceTest {
         final DirectoryLdapModel directoryLdapModel = DirectoryLdapModel.builder().build();
 
         assertThrows(BadRequestException.class, () -> {
-            directoryService.setDirectory(1L, directoryLdapModel, false);
+            directoryService.setDirectory(1L, directoryLdapModel);
         });
     }
 
@@ -164,7 +164,7 @@ class DirectoryServiceTest {
         final AbstractDirectoryModel directoryModel = DirectoryModelUtil.toDirectoryModel(directory);
 
         assertThrows(NotFoundException.class, () -> {
-            directoryService.setDirectory(1L, directoryModel, false);
+            directoryService.setDirectory(1L, directoryModel);
         });
     }
 
@@ -177,7 +177,7 @@ class DirectoryServiceTest {
         DirectoryCrowdModel directoryModel = (DirectoryCrowdModel) DirectoryModelUtil.toDirectoryModel(directory);
 
         assertThrows(IllegalArgumentException.class, () -> {
-            directoryService.addDirectory(directoryModel, false);
+            directoryService.addDirectory(directoryModel);
         });
     }
 
@@ -189,7 +189,7 @@ class DirectoryServiceTest {
         DirectoryCrowdModel directoryModel = (DirectoryCrowdModel) DirectoryModelUtil.toDirectoryModel(directory);
         directoryModel.getServer().setAppPassword("test");
 
-        AbstractDirectoryModel directoryAdded = directoryService.addDirectory(directoryModel, false);
+        AbstractDirectoryModel directoryAdded = directoryService.addDirectory(directoryModel);
         assertEquals(directoryAdded.getName(), directoryModel.getName());
         assertEquals(directoryAdded.getId(), directoryModel.getId());
     }
@@ -199,7 +199,7 @@ class DirectoryServiceTest {
         final DirectoryLdapModel directoryLdapModel = DirectoryLdapModel.builder().build();
 
         assertThrows(BadRequestException.class, () -> {
-            directoryService.addDirectory(directoryLdapModel, false);
+            directoryService.addDirectory(directoryLdapModel);
         });
     }
 


### PR DESCRIPTION
Change bulk REST endpoints (application links, directories, users, authentication IDPs) from list-based to map-based payloads keyed by name. Introduce AbstractDirectoryExternalModel for shared external directory properties. Update integration tests accordingly.