### PR TITLE
Support key-only (null model) entries in nested map structures for groups and users

### DIFF
--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceImpl.java
@@ -108,7 +108,14 @@ public class GroupsServiceImpl implements GroupsService {
         final Group group = findGroup(directoryId, groupName);
 
         if (group == null) {
+            if (groupModel == null) {
+                throw new GroupNotFoundException(groupName);
+            }
             return createGroup(directoryId, groupModel);
+        }
+
+        if (groupModel == null) {
+            return GroupModelUtil.toGroupModel(group);
         }
 
         return updateGroup(directoryId, groupName, groupModel);

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceImpl.java
@@ -81,7 +81,14 @@ public class UsersServiceImpl implements UsersService {
         final User user = findUser(directoryId, username);
 
         if (user == null) {
+            if (userModel == null) {
+                throw new UserNotFoundException(username);
+            }
             return addUser(directoryId, username, userModel);
+        }
+
+        if (userModel == null) {
+            return UserModelUtil.toUserModel(user);
         }
 
         return updateUser(directoryId, user.getName(), userModel);

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceTest.java
@@ -191,6 +191,24 @@ public class GroupsServiceTest {
     }
 
     @Test
+    public void testSetGroupNullModelAddNew() {
+        final Group group = getTestGroup();
+        assertThrows(GroupNotFoundException.class, () ->
+                groupsService.setGroup(group.getDirectoryId(), group.getName(), null));
+    }
+
+    @Test
+    public void testSetGroupNullModelExisting() {
+        final Group group = getTestGroup();
+        final GroupsServiceImpl spy = spy(groupsService);
+        doReturn(group).when(spy).findGroup(group.getDirectoryId(), group.getName());
+
+        spy.setGroup(group.getDirectoryId(), group.getName(), null);
+        verify(spy, never()).createGroup(anyLong(), any());
+        verify(spy, never()).updateGroup(anyLong(), anyString(), any());
+    }
+
+    @Test
     public void testSetGroupsNull() {
         assertEquals(Collections.emptyMap(), groupsService.setGroups(0L, null));
     }

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceTest.java
@@ -143,6 +143,24 @@ public class UsersServiceTest {
     }
 
     @Test
+    public void testSetUserNullModelAddNew() {
+        final User user = getTestUser();
+        assertThrows(UserNotFoundException.class, () ->
+                usersService.setUser(user.getDirectoryId(), user.getName(), null));
+    }
+
+    @Test
+    public void testSetUserNullModelExisting() throws CrowdException {
+        final User user = getTestUser();
+        final UsersServiceImpl spy = spy(usersService);
+        doReturn(user).when(spy).findUser(user.getDirectoryId(), user.getName());
+
+        spy.setUser(user.getDirectoryId(), user.getName(), null);
+        verify(spy, never()).addUser(anyLong(), anyString(), any());
+        verify(spy, never()).updateUser(anyLong(), anyString(), any());
+    }
+
+    @Test
     public void testSetUsers() {
         final User user = getTestUser();
         final UserModel userModel = UserModelUtil.toUserModel(user);


### PR DESCRIPTION
setGroup and setUser now accept a null model value. If the entity already exists it is returned as-is without any updates. If it does not exist, a 404 is returned, since the key-only form is meant to reference an existing entity, not create one.