### PR TITLE
Add DELETE for the default SMTP and POP mail servers

### DIFF
--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerPopModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerPopModel.java
@@ -22,11 +22,14 @@ public class MailServerPopModel extends AbstractMailServerProtocolModel {
         .host("mail.example.com")
         .build();
 
+    // greenmail-compatible so functional tests can apply it against the integration
+    // test environment (see ci.yaml)
     public static final MailServerPopModel EXAMPLE_2 = MailServerPopModel.builder()
         .name("Example")
-        .host("mail.example.com")
-        .port(110)
         .protocol("pop3")
+        .host("localhost")
+        .port(3110)
+        .timeout(5000L)
         .build();
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerSmtpModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerSmtpModel.java
@@ -44,18 +44,17 @@ public class MailServerSmtpModel extends AbstractMailServerProtocolModel {
         .host("mail.example.com")
         .build();
 
+    // greenmail-compatible so functional tests can apply it against the integration
+    // test environment (see ci.yaml); only fields that products echo back are set
     public static final MailServerSmtpModel EXAMPLE_2 = MailServerSmtpModel.builder()
         .name("Example")
-        .adminContact(null)
         .from("mail@example.com")
         .prefix("[Example]")
-        .host("mail.example.com")
-        .description("test smtp server")
-        .port(25)
         .protocol("smtp")
-        .timeout(2000L)
-        .username("admin")
-        .password("password")
+        .host("localhost")
+        .port(3025)
+        .useTls(false)
+        .timeout(5000L)
         .build();
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerResourceImpl.java
@@ -54,4 +54,16 @@ public class AbstractMailServerResourceImpl implements MailServerResource {
         final MailServerPopModel updatedPopModel = mailServerService.setMailServerPop(bean);
         return Response.ok(updatedPopModel).build();
     }
+
+    @Override
+    public Response deleteMailServerSmtp() {
+        mailServerService.deleteMailServerSmtp();
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response deleteMailServerPop() {
+        mailServerService.deleteMailServerPop();
+        return Response.noContent().build();
+    }
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerPopResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerPopResource.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -61,5 +62,24 @@ public interface MailServerPopResource {
     )
     Response setMailServerPop(
             final MailServerPopModel bean);
+
+    @DELETE
+    @Path(BootstrAPI.MAIL_SERVER_POP)
+    @Operation(
+            tags = { BootstrAPI.MAIL_SERVER },
+            summary = "Remove the default POP mail server",
+            description = "Removes the default POP mail server if one is configured; does nothing otherwise.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "The default POP mail server has been removed or none was configured."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
+            }
+    )
+    Response deleteMailServerPop();
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerSmtpResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerSmtpResource.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -61,5 +62,24 @@ public interface MailServerSmtpResource {
     )
     Response setMailServerSmtp(
             final MailServerSmtpModel bean);
+
+    @DELETE
+    @Path(BootstrAPI.MAIL_SERVER_SMTP)
+    @Operation(
+            tags = { BootstrAPI.MAIL_SERVER },
+            summary = "Remove the default SMTP mail server",
+            description = "Removes the default SMTP mail server if one is configured; does nothing otherwise.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "The default SMTP mail server has been removed or none was configured."
+                    ),
+                    @ApiResponse(
+                            responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    ),
+            }
+    )
+    Response deleteMailServerSmtp();
 
 }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/MailServerService.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/service/api/MailServerService.java
@@ -23,6 +23,11 @@ public interface MailServerService {
             final MailServerSmtpModel smtpModel);
 
     /**
+     * Removes the default smtp mailserver if one is configured; does nothing otherwise.
+     */
+    void deleteMailServerSmtp();
+
+    /**
      * Get the pop mailserver settings.
      *
      * @return the pop mailserver settings
@@ -37,4 +42,9 @@ public interface MailServerService {
      */
     MailServerPopModel setMailServerPop(
             final MailServerPopModel popModel);
+
+    /**
+     * Removes the default pop mailserver if one is configured; does nothing otherwise.
+     */
+    void deleteMailServerPop();
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/MailServerResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/MailServerResourceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class MailServerResourceTest {
@@ -77,5 +78,21 @@ class MailServerResourceTest {
         final MailServerPopModel popModel = (MailServerPopModel) response.getEntity();
 
         assertEquals(popModel, bean);
+    }
+
+    @Test
+    void testDeleteMailServerSmtp() {
+        final Response response = resource.deleteMailServerSmtp();
+
+        assertEquals(204, response.getStatus());
+        verify(mailServerService).deleteMailServerSmtp();
+    }
+
+    @Test
+    void testDeleteMailServerPop() {
+        final Response response = resource.deleteMailServerPop();
+
+        assertEquals(204, response.getStatus());
+        verify(mailServerService).deleteMailServerPop();
     }
 }

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
@@ -23,6 +23,12 @@ public abstract class AbstractMailServerPopResourceFuncTest {
     @Test
     @Order(1)
     protected void testGetMailServerPopNotConfigured() throws Exception {
+        // delete any existing configuration first so this test does not depend
+        // on the state left behind by other test classes
+        final HttpResponse<String> deleteResponse = HttpRequestHelper.builder(BootstrAPI.MAIL_SERVER + "/" + BootstrAPI.MAIL_SERVER_POP)
+                .request(HttpMethod.DELETE, null);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), deleteResponse.statusCode());
+
         final HttpResponse<String> mailServerPopResponse = HttpRequestHelper.builder(BootstrAPI.MAIL_SERVER + "/" + BootstrAPI.MAIL_SERVER_POP)
                 .request();
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), mailServerPopResponse.statusCode());

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
@@ -23,6 +23,12 @@ public abstract class AbstractMailServerSmtpResourceFuncTest {
     @Test
     @Order(1)
     protected void testGetMailServerSmtpNotConfigured() throws Exception {
+        // delete any existing configuration first so this test does not depend
+        // on the state left behind by other test classes
+        final HttpResponse<String> deleteResponse = HttpRequestHelper.builder(BootstrAPI.MAIL_SERVER + "/" + BootstrAPI.MAIL_SERVER_SMTP)
+                .request(HttpMethod.DELETE, null);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), deleteResponse.statusCode());
+
         final HttpResponse<String> mailServerSmtpResponse = HttpRequestHelper.builder(BootstrAPI.MAIL_SERVER + "/" + BootstrAPI.MAIL_SERVER_SMTP)
                 .request();
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), mailServerSmtpResponse.statusCode());

--- a/confluence/Apis/MailServerApi.md
+++ b/confluence/Apis/MailServerApi.md
@@ -4,11 +4,61 @@ All URIs are relative to *https://CONFLUENCE_URL/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**deleteMailServerPop**](MailServerApi.md#deleteMailServerPop) | **DELETE** /mail-server/pop | Remove the default POP mail server |
+| [**deleteMailServerSmtp**](MailServerApi.md#deleteMailServerSmtp) | **DELETE** /mail-server/smtp | Remove the default SMTP mail server |
 | [**getMailServerPop**](MailServerApi.md#getMailServerPop) | **GET** /mail-server/pop | Get the default POP mail server |
 | [**getMailServerSmtp**](MailServerApi.md#getMailServerSmtp) | **GET** /mail-server/smtp | Get the default SMTP mail server |
 | [**setMailServerPop**](MailServerApi.md#setMailServerPop) | **PUT** /mail-server/pop | Set the default POP mail server |
 | [**setMailServerSmtp**](MailServerApi.md#setMailServerSmtp) | **PUT** /mail-server/smtp | Set the default SMTP mail server |
 
+
+<a name="deleteMailServerPop"></a>
+# **deleteMailServerPop**
+> deleteMailServerPop()
+
+Remove the default POP mail server
+
+    Removes the default POP mail server if one is configured; does nothing otherwise.
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: */*
+
+<a name="deleteMailServerSmtp"></a>
+# **deleteMailServerSmtp**
+> deleteMailServerSmtp()
+
+Remove the default SMTP mail server
+
+    Removes the default SMTP mail server if one is configured; does nothing otherwise.
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: */*
 
 <a name="getMailServerPop"></a>
 # **getMailServerPop**

--- a/confluence/README.md
+++ b/confluence/README.md
@@ -32,7 +32,9 @@ All URIs are relative to *https://CONFLUENCE_URL/rest/bootstrapi/1*
 | *LicenseApi* | [**addLicense**](Apis/LicenseApi.md#addLicense) | **POST** /license | Add a license |
 | *LicensesApi* | [**getLicenses**](Apis/LicensesApi.md#getLicenses) | **GET** /licenses | Get all licenses information |
 *LicensesApi* | [**setLicenses**](Apis/LicensesApi.md#setLicenses) | **PUT** /licenses | Set a list of licenses |
-| *MailServerApi* | [**getMailServerPop**](Apis/MailServerApi.md#getMailServerPop) | **GET** /mail-server/pop | Get the default POP mail server |
+| *MailServerApi* | [**deleteMailServerPop**](Apis/MailServerApi.md#deleteMailServerPop) | **DELETE** /mail-server/pop | Remove the default POP mail server |
+*MailServerApi* | [**deleteMailServerSmtp**](Apis/MailServerApi.md#deleteMailServerSmtp) | **DELETE** /mail-server/smtp | Remove the default SMTP mail server |
+*MailServerApi* | [**getMailServerPop**](Apis/MailServerApi.md#getMailServerPop) | **GET** /mail-server/pop | Get the default POP mail server |
 *MailServerApi* | [**getMailServerSmtp**](Apis/MailServerApi.md#getMailServerSmtp) | **GET** /mail-server/smtp | Get the default SMTP mail server |
 *MailServerApi* | [**setMailServerPop**](Apis/MailServerApi.md#setMailServerPop) | **PUT** /mail-server/pop | Set the default POP mail server |
 *MailServerApi* | [**setMailServerSmtp**](Apis/MailServerApi.md#setMailServerSmtp) | **PUT** /mail-server/smtp | Set the default SMTP mail server |

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/MailServerServiceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/service/MailServerServiceImpl.java
@@ -142,4 +142,34 @@ public class MailServerServiceImpl implements MailServerService {
 
         return getMailServerPop();
     }
+
+    @Override
+    public void deleteMailServerSmtp() {
+        final SMTPMailServer smtpMailServer = mailServerManager.getDefaultSMTPMailServer();
+
+        if (smtpMailServer == null) {
+            return;
+        }
+
+        try {
+            mailServerManager.delete(smtpMailServer.getId());
+        } catch (MailException e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    @Override
+    public void deleteMailServerPop() {
+        final PopMailServer popMailServer = mailServerManager.getDefaultPopMailServer();
+
+        if (popMailServer == null) {
+            return;
+        }
+
+        try {
+            mailServerManager.delete(popMailServer.getId());
+        } catch (MailException e) {
+            throw new BadRequestException(e);
+        }
+    }
 }

--- a/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/MailServerServiceTest.java
+++ b/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/MailServerServiceTest.java
@@ -216,4 +216,44 @@ class MailServerServiceTest {
             mailServerService.setMailServerPop(requestMailServerPopModel);
         });
     }
+
+    @Test
+    void testDeleteMailServerSmtp() throws Exception {
+        final SMTPMailServer smtpMailServer = new DefaultTestSmtpMailServerImpl();
+        doReturn(smtpMailServer).when(mailServerManager).getDefaultSMTPMailServer();
+
+        mailServerService.deleteMailServerSmtp();
+
+        verify(mailServerManager).delete(smtpMailServer.getId());
+    }
+
+    @Test
+    void testDeleteMailServerSmtpNotConfigured() throws Exception {
+        doReturn(null).when(mailServerManager).getDefaultSMTPMailServer();
+
+        mailServerService.deleteMailServerSmtp();
+
+        verify(mailServerManager, never()).delete(any());
+    }
+
+    @Test
+    void testDeleteMailServerPop() throws Exception {
+        final PopMailServer popMailServer = new DefaultTestPopMailServerImpl();
+        doReturn(popMailServer).when(mailServerManager).getDefaultPopMailServer();
+
+        mailServerService.deleteMailServerPop();
+
+        verify(mailServerManager).delete(popMailServer.getId());
+    }
+
+    @Test
+    void testDeleteMailServerSmtpException() throws Exception {
+        final SMTPMailServer smtpMailServer = new DefaultTestSmtpMailServerImpl();
+        doReturn(smtpMailServer).when(mailServerManager).getDefaultSMTPMailServer();
+        doThrow(new MailException("delete failed")).when(mailServerManager).delete(smtpMailServer.getId());
+
+        assertThrows(BadRequestException.class, () -> {
+            mailServerService.deleteMailServerSmtp();
+        });
+    }
 }

--- a/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/MailServerPopResourceFuncTest.java
+++ b/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/MailServerPopResourceFuncTest.java
@@ -1,27 +1,5 @@
 package it.com.deftdevs.bootstrapi.confluence.rest;
 
-import com.deftdevs.bootstrapi.commons.model.MailServerPopModel;
 import it.com.deftdevs.bootstrapi.commons.rest.AbstractMailServerPopResourceFuncTest;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
 
-public class MailServerPopResourceFuncTest extends AbstractMailServerPopResourceFuncTest {
-
-    @Test
-    @Order(1)
-    @Override
-    protected void testGetMailServerPopNotConfigured() {
-        // no-op: Confluence's test instance already has POP mail configuration
-    }
-
-    @Override
-    protected MailServerPopModel getExampleModel() {
-        return MailServerPopModel.builder()
-                .name("Test POP Server")
-                .protocol("pop3")
-                .host("localhost")
-                .port(3110)
-                .timeout(5000L)
-                .build();
-    }
-}
+public class MailServerPopResourceFuncTest extends AbstractMailServerPopResourceFuncTest { }

--- a/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/MailServerSmtpResourceFuncTest.java
+++ b/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/MailServerSmtpResourceFuncTest.java
@@ -1,30 +1,5 @@
 package it.com.deftdevs.bootstrapi.confluence.rest;
 
-import com.deftdevs.bootstrapi.commons.model.MailServerSmtpModel;
 import it.com.deftdevs.bootstrapi.commons.rest.AbstractMailServerSmtpResourceFuncTest;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
 
-public class MailServerSmtpResourceFuncTest extends AbstractMailServerSmtpResourceFuncTest {
-
-    @Test
-    @Order(1)
-    @Override
-    protected void testGetMailServerSmtpNotConfigured() {
-        // no-op: Confluence's test instance already has SMTP mail configuration
-    }
-
-    @Override
-    protected MailServerSmtpModel getExampleModel() {
-        return MailServerSmtpModel.builder()
-                .name("Test SMTP Server")
-                .from("test@example.com")
-                .prefix("[Test]")
-                .protocol("smtp")
-                .host("localhost")
-                .port(3025)
-                .useTls(false)
-                .timeout(5000L)
-                .build();
-    }
-}
+public class MailServerSmtpResourceFuncTest extends AbstractMailServerSmtpResourceFuncTest { }

--- a/crowd/Apis/MailServerApi.md
+++ b/crowd/Apis/MailServerApi.md
@@ -4,9 +4,34 @@ All URIs are relative to *https://CROWD_URL/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**deleteMailServerSmtp**](MailServerApi.md#deleteMailServerSmtp) | **DELETE** /mail-server/smtp | Remove the default SMTP mail server |
 | [**getMailServerSmtp**](MailServerApi.md#getMailServerSmtp) | **GET** /mail-server/smtp | Get the default SMTP mail server |
 | [**setMailServerSmtp**](MailServerApi.md#setMailServerSmtp) | **PUT** /mail-server/smtp | Set the default SMTP mail server |
 
+
+<a name="deleteMailServerSmtp"></a>
+# **deleteMailServerSmtp**
+> deleteMailServerSmtp()
+
+Remove the default SMTP mail server
+
+    Removes the default SMTP mail server if one is configured; does nothing otherwise.
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: */*
 
 <a name="getMailServerSmtp"></a>
 # **getMailServerSmtp**

--- a/crowd/README.md
+++ b/crowd/README.md
@@ -35,7 +35,8 @@ All URIs are relative to *https://CROWD_URL/rest/bootstrapi/1*
 | *LicenseApi* | [**addLicense**](Apis/LicenseApi.md#addLicense) | **POST** /license | Add a license |
 | *LicensesApi* | [**getLicenses**](Apis/LicensesApi.md#getLicenses) | **GET** /licenses | Get all licenses information |
 *LicensesApi* | [**setLicenses**](Apis/LicensesApi.md#setLicenses) | **PUT** /licenses | Set a list of licenses |
-| *MailServerApi* | [**getMailServerSmtp**](Apis/MailServerApi.md#getMailServerSmtp) | **GET** /mail-server/smtp | Get the default SMTP mail server |
+| *MailServerApi* | [**deleteMailServerSmtp**](Apis/MailServerApi.md#deleteMailServerSmtp) | **DELETE** /mail-server/smtp | Remove the default SMTP mail server |
+*MailServerApi* | [**getMailServerSmtp**](Apis/MailServerApi.md#getMailServerSmtp) | **GET** /mail-server/smtp | Get the default SMTP mail server |
 *MailServerApi* | [**setMailServerSmtp**](Apis/MailServerApi.md#setMailServerSmtp) | **PUT** /mail-server/smtp | Set the default SMTP mail server |
 | *MailTemplatesApi* | [**getMailTemplates**](Apis/MailTemplatesApi.md#getMailTemplates) | **GET** /mail-templates | Get the mail templates |
 *MailTemplatesApi* | [**setMailTemplates**](Apis/MailTemplatesApi.md#setMailTemplates) | **PUT** /mail-templates | Set the mail templates |

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/MailServerResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/MailServerResourceImpl.java
@@ -40,4 +40,10 @@ public class MailServerResourceImpl implements MailServerSmtpResource {
         return Response.ok(updatedSmtpModel).build();
     }
 
+    @Override
+    public Response deleteMailServerSmtp() {
+        mailServerService.deleteMailServerSmtp();
+        return Response.noContent().build();
+    }
+
 }

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/MailServerServiceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/MailServerServiceImpl.java
@@ -36,6 +36,11 @@ public class MailServerServiceImpl implements MailServerService {
     }
 
     @Override
+    public void deleteMailServerSmtp() {
+        throw new UnsupportedOperationException("Deleting SMTP mail server is not supported by Crowd");
+    }
+
+    @Override
     public MailServerPopModel getMailServerPop() {
         throw new UnsupportedOperationException("Getting POP mail server is not supported by Crowd");
     }
@@ -45,5 +50,10 @@ public class MailServerServiceImpl implements MailServerService {
             final MailServerPopModel mailServerPopModel) {
 
         throw new UnsupportedOperationException("Setting POP mail server is not supported by Crowd");
+    }
+
+    @Override
+    public void deleteMailServerPop() {
+        throw new UnsupportedOperationException("Deleting POP mail server is not supported by Crowd");
     }
 }

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/MailServerServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/MailServerServiceTest.java
@@ -107,4 +107,18 @@ public class MailServerServiceTest {
             mailServerService.setMailServerPop(null);
         });
     }
+
+    @Test
+    public void testDeleteMailServerSmtp() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            mailServerService.deleteMailServerSmtp();
+        });
+    }
+
+    @Test
+    public void testDeleteMailServerPop() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            mailServerService.deleteMailServerPop();
+        });
+    }
 }

--- a/jira/Apis/MailServerApi.md
+++ b/jira/Apis/MailServerApi.md
@@ -4,11 +4,61 @@ All URIs are relative to *https://JIRA_URL/rest/bootstrapi/1*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**deleteMailServerPop**](MailServerApi.md#deleteMailServerPop) | **DELETE** /mail-server/pop | Remove the default POP mail server |
+| [**deleteMailServerSmtp**](MailServerApi.md#deleteMailServerSmtp) | **DELETE** /mail-server/smtp | Remove the default SMTP mail server |
 | [**getMailServerPop**](MailServerApi.md#getMailServerPop) | **GET** /mail-server/pop | Get the default POP mail server |
 | [**getMailServerSmtp**](MailServerApi.md#getMailServerSmtp) | **GET** /mail-server/smtp | Get the default SMTP mail server |
 | [**setMailServerPop**](MailServerApi.md#setMailServerPop) | **PUT** /mail-server/pop | Set the default POP mail server |
 | [**setMailServerSmtp**](MailServerApi.md#setMailServerSmtp) | **PUT** /mail-server/smtp | Set the default SMTP mail server |
 
+
+<a name="deleteMailServerPop"></a>
+# **deleteMailServerPop**
+> deleteMailServerPop()
+
+Remove the default POP mail server
+
+    Removes the default POP mail server if one is configured; does nothing otherwise.
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: */*
+
+<a name="deleteMailServerSmtp"></a>
+# **deleteMailServerSmtp**
+> deleteMailServerSmtp()
+
+Remove the default SMTP mail server
+
+    Removes the default SMTP mail server if one is configured; does nothing otherwise.
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: */*
 
 <a name="getMailServerPop"></a>
 # **getMailServerPop**

--- a/jira/README.md
+++ b/jira/README.md
@@ -28,7 +28,9 @@ All URIs are relative to *https://JIRA_URL/rest/bootstrapi/1*
 | *LicenseApi* | [**addLicense**](Apis/LicenseApi.md#addLicense) | **POST** /license | Add a license |
 | *LicensesApi* | [**getLicenses**](Apis/LicensesApi.md#getLicenses) | **GET** /licenses | Get all licenses information |
 *LicensesApi* | [**setLicenses**](Apis/LicensesApi.md#setLicenses) | **PUT** /licenses | Set a list of licenses |
-| *MailServerApi* | [**getMailServerPop**](Apis/MailServerApi.md#getMailServerPop) | **GET** /mail-server/pop | Get the default POP mail server |
+| *MailServerApi* | [**deleteMailServerPop**](Apis/MailServerApi.md#deleteMailServerPop) | **DELETE** /mail-server/pop | Remove the default POP mail server |
+*MailServerApi* | [**deleteMailServerSmtp**](Apis/MailServerApi.md#deleteMailServerSmtp) | **DELETE** /mail-server/smtp | Remove the default SMTP mail server |
+*MailServerApi* | [**getMailServerPop**](Apis/MailServerApi.md#getMailServerPop) | **GET** /mail-server/pop | Get the default POP mail server |
 *MailServerApi* | [**getMailServerSmtp**](Apis/MailServerApi.md#getMailServerSmtp) | **GET** /mail-server/smtp | Get the default SMTP mail server |
 *MailServerApi* | [**setMailServerPop**](Apis/MailServerApi.md#setMailServerPop) | **PUT** /mail-server/pop | Set the default POP mail server |
 *MailServerApi* | [**setMailServerSmtp**](Apis/MailServerApi.md#setMailServerSmtp) | **PUT** /mail-server/smtp | Set the default SMTP mail server |

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/MailServerServiceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/service/MailServerServiceImpl.java
@@ -145,4 +145,34 @@ public class MailServerServiceImpl implements MailServerService {
         return mailServerPopModel;
     }
 
+    @Override
+    public void deleteMailServerSmtp() {
+        final SMTPMailServer smtpMailServer = mailServerManager.getDefaultSMTPMailServer();
+
+        if (smtpMailServer == null) {
+            return;
+        }
+
+        try {
+            mailServerManager.delete(smtpMailServer.getId());
+        } catch (MailException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    @Override
+    public void deleteMailServerPop() {
+        final PopMailServer popMailServer = mailServerManager.getDefaultPopMailServer();
+
+        if (popMailServer == null) {
+            return;
+        }
+
+        try {
+            mailServerManager.delete(popMailServer.getId());
+        } catch (MailException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
 }

--- a/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/MailServerServiceTest.java
+++ b/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/MailServerServiceTest.java
@@ -234,4 +234,44 @@ class MailServerServiceTest {
         });
     }
 
+    @Test
+    void testDeleteMailServerSmtp() throws Exception {
+        final SMTPMailServer smtpMailServer = new DefaultTestSmtpMailServerImpl();
+        doReturn(smtpMailServer).when(mailServerManager).getDefaultSMTPMailServer();
+
+        mailServerService.deleteMailServerSmtp();
+
+        verify(mailServerManager).delete(smtpMailServer.getId());
+    }
+
+    @Test
+    void testDeleteMailServerSmtpNotConfigured() throws Exception {
+        doReturn(null).when(mailServerManager).getDefaultSMTPMailServer();
+
+        mailServerService.deleteMailServerSmtp();
+
+        verify(mailServerManager, never()).delete(any());
+    }
+
+    @Test
+    void testDeleteMailServerPop() throws Exception {
+        final PopMailServer popMailServer = new DefaultTestPopMailServerImpl();
+        doReturn(popMailServer).when(mailServerManager).getDefaultPopMailServer();
+
+        mailServerService.deleteMailServerPop();
+
+        verify(mailServerManager).delete(popMailServer.getId());
+    }
+
+    @Test
+    void testDeleteMailServerSmtpException() throws Exception {
+        final SMTPMailServer smtpMailServer = new DefaultTestSmtpMailServerImpl();
+        doReturn(smtpMailServer).when(mailServerManager).getDefaultSMTPMailServer();
+        doThrow(new MailException("delete failed")).when(mailServerManager).delete(smtpMailServer.getId());
+
+        assertThrows(BadRequestException.class, () -> {
+            mailServerService.deleteMailServerSmtp();
+        });
+    }
+
 }

--- a/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/MailServerPopResourceFuncTest.java
+++ b/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/MailServerPopResourceFuncTest.java
@@ -1,18 +1,5 @@
 package it.com.deftdevs.bootstrapi.jira.rest;
 
-import com.deftdevs.bootstrapi.commons.model.MailServerPopModel;
 import it.com.deftdevs.bootstrapi.commons.rest.AbstractMailServerPopResourceFuncTest;
 
-public class MailServerPopResourceFuncTest extends AbstractMailServerPopResourceFuncTest {
-
-    @Override
-    protected MailServerPopModel getExampleModel() {
-        return MailServerPopModel.builder()
-                .name("Test POP Server")
-                .protocol("pop3")
-                .host("localhost")
-                .port(3110)
-                .timeout(5000L)
-                .build();
-    }
-}
+public class MailServerPopResourceFuncTest extends AbstractMailServerPopResourceFuncTest { }

--- a/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/MailServerSmtpResourceFuncTest.java
+++ b/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/MailServerSmtpResourceFuncTest.java
@@ -1,21 +1,5 @@
 package it.com.deftdevs.bootstrapi.jira.rest;
 
-import com.deftdevs.bootstrapi.commons.model.MailServerSmtpModel;
 import it.com.deftdevs.bootstrapi.commons.rest.AbstractMailServerSmtpResourceFuncTest;
 
-public class MailServerSmtpResourceFuncTest extends AbstractMailServerSmtpResourceFuncTest {
-
-    @Override
-    protected MailServerSmtpModel getExampleModel() {
-        return MailServerSmtpModel.builder()
-                .name("Test SMTP Server")
-                .from("test@example.com")
-                .prefix("[Test]")
-                .protocol("smtp")
-                .host("localhost")
-                .port(3025)
-                .useTls(false)
-                .timeout(5000L)
-                .build();
-    }
-}
+public class MailServerSmtpResourceFuncTest extends AbstractMailServerSmtpResourceFuncTest { }


### PR DESCRIPTION
Allows removing the default mail server configuration through the API; the operation is idempotent and returns 204 whether or not a server was configured. Crowd does not support removing its mail configuration and throws UnsupportedOperationException, consistent with its POP operations.

This also makes the mail server functional tests deterministic and duplication-free: the "not configured" precondition tests now delete any existing configuration first instead of relying on a pristine instance, so they no longer depend on test class execution order or on a freshly extracted product home. The EXAMPLE_2 mail server models are redefined to be greenmail-compatible (see ci.yaml), letting the Confluence and Jira functional tests use the shared defaults instead of per-product overrides.