### PR TITLE
Yaml request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,21 @@ BootstrAPI
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
-BootstrAPI is a series of plugins for providing additional REST API's for Atlassian products with focus on initial and declarative instance configuration (also referred to as "bootstrapping", hence the name).
+BootstrAPI is a series of plugins for providing additional REST APIs for Atlassian products with focus on initial and declarative instance configuration (also referred to as "bootstrapping", hence the name). Configuration documents are declarative and idempotent - applying the same document again is safe - which makes the API a natural fit for automated provisioning.
+
+## Plugins
+
+- [Confluence](confluence) ([documentation](confluence/README.md))
+- [Crowd](crowd) ([documentation](crowd/README.md))
+- [Jira](jira) ([documentation](jira/README.md))
 
 ## Example
 
-The same configuration models work across all products. A minimal configuration applying the general settings and an SMTP mail server:
+The same configuration models work across all products. A minimal configuration applying the general settings and an SMTP mail server, in a single request via the `_all` endpoint (the REST root) - YAML is accepted directly, JSON works just as well:
 
-```yaml
-# config.yaml
+```sh
+curl -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" -X PUT -H "Content-Type: application/yaml" \
+    --data-binary @- https://confluence.example.com/rest/bootstrapi/1/ <<EOF
 settings:
   general:
     title: Example
@@ -24,24 +31,20 @@ mailServer:
     from: mail@example.com
     host: mail.example.com
     port: 25
+EOF
 ```
 
-Apply it in a single request via the `_all` endpoint (the REST root), e.g. with [yq](https://github.com/mikefarah/yq) and curl:
-
-```sh
-yq -o=json config.yaml | curl -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" -X PUT -H "Content-Type: application/json" -d @- \
-    https://confluence.example.com/rest/bootstrapi/1/
-```
-
-The very same document — with the product's own base URL — configures Jira via `https://jira.example.com/rest/bootstrapi/1/` and Crowd via `https://crowd.example.com/crowd/rest/bootstrapi/1/`. Product-specific sub-fields (e.g. Jira's `settings.branding.banner` or Crowd's `trustedProxies`) can simply be added to the same document.
+The very same document - with the product's own base URL - configures Jira via `https://jira.example.com/rest/bootstrapi/1/` and Crowd via `https://crowd.example.com/crowd/rest/bootstrapi/1/`. Product-specific sub-fields (e.g. Jira's `settings.branding.banner` or Crowd's `trustedProxies`) can simply be added to the same document.
 
 Every sub-field present in the request is applied independently: the response echoes the resulting configuration and reports each sub-field's outcome in its `status` map, keyed by the request's field paths (e.g. `settings/general`, `mailServer/smtp`), answering with the highest sub-field status code.
 
-## Plugins
+## Installation
 
-- [Confluence](confluence) ([documentation](confluence/README.md))
-- [Crowd](crowd) ([documentation](crowd/README.md))
-- [Jira](jira) ([documentation](jira/README.md))
+Download the plugin for your product from the [releases](https://github.com/deftdevs/bootstrapi/releases) and upload it in the product's administration under *Manage apps* → *Upload app*. The endpoints require a user with system administrator permissions.
+
+## Compatibility
+
+The plugins are built and tested against Confluence 9.x, Jira 10.x and Crowd 6.x (Data Center).
 
 ## About
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -193,6 +193,20 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- bundled: the products provide the Jackson core artifacts (2.17.x) but not the YAML dataformat,
+             so the version must match the platform Jackson version, not ${jackson.version} -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.17.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/constants/BootstrAPI.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/constants/BootstrAPI.java
@@ -61,6 +61,9 @@ public class BootstrAPI {
     public static final String USER_PASSWORD                = "password";
 
     public static final String MEDIA_TYPE_IMAGE             = "image/*";
+    public static final String MEDIA_TYPE_YAML              = "application/yaml";
+    public static final String MEDIA_TYPE_YAML_LEGACY       = "application/x-yaml";
+    public static final String MEDIA_TYPE_YAML_TEXT         = "text/yaml";
 
     public static final String ERROR_COLLECTION_RESPONSE_DESCRIPTION      = "Returns a list of error messages.";
     public static final String _ALL_PUT_SUMMARY                           = "Apply a complete configuration";

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinkResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinkResource.java
@@ -23,7 +23,7 @@ public interface ApplicationLinkResource {
 
     @GET
     @Path("{uuid}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION_LINK },
             summary = "Get an application link",
@@ -43,8 +43,8 @@ public interface ApplicationLinkResource {
             @PathParam("uuid") final UUID uuid);
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION_LINK },
             summary = "Create an application link",
@@ -64,8 +64,8 @@ public interface ApplicationLinkResource {
 
     @PUT
     @Path("{uuid}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION_LINK },
             summary = "Update an application link",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public interface ApplicationLinksResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION_LINKS },
             summary = "Get all application links",
@@ -39,8 +39,8 @@ public interface ApplicationLinksResource {
     Map<String, ApplicationLinkModel> getApplicationLinks();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION_LINKS },
             summary = "Set a list of application links",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/AuthenticationResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/AuthenticationResource.java
@@ -22,7 +22,7 @@ public interface AuthenticationResource {
 
     @GET
     @Path(BootstrAPI.AUTHENTICATION_IDPS)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.AUTHENTICATION },
             summary = "Get all authentication identity providers",
@@ -40,8 +40,8 @@ public interface AuthenticationResource {
 
     @PATCH
     @Path(BootstrAPI.AUTHENTICATION_IDPS)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.AUTHENTICATION },
             summary = "Set all authentication identity providers",
@@ -60,7 +60,7 @@ public interface AuthenticationResource {
 
     @GET
     @Path(BootstrAPI.AUTHENTICATION_SSO)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.AUTHENTICATION },
             summary = "Get authentication SSO configuration",
@@ -78,8 +78,8 @@ public interface AuthenticationResource {
 
     @PATCH
     @Path(BootstrAPI.AUTHENTICATION_SSO)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.AUTHENTICATION },
             summary = "Set authentication SSO configuration",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public interface DirectoriesResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.DIRECTORIES },
             summary = "Get all user directories",
@@ -38,8 +38,8 @@ public interface DirectoriesResource {
     Map<String, ? extends AbstractDirectoryModel> getDirectories();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.DIRECTORIES },
             summary = "Set directories mapped by their name.",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoryResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoryResource.java
@@ -22,7 +22,7 @@ public interface DirectoryResource {
 
     @GET
     @Path("{id}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.DIRECTORY },
             summary = "Get a user directory",
@@ -41,8 +41,8 @@ public interface DirectoryResource {
             @PathParam("id") final long id);
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.DIRECTORY },
             summary = "Create a user directory",
@@ -62,8 +62,8 @@ public interface DirectoryResource {
 
     @PUT
     @Path("{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.DIRECTORY },
             summary = "Update a user directory",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicenseResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicenseResource.java
@@ -16,8 +16,8 @@ import javax.ws.rs.core.Response;
 public interface LicenseResource {
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.LICENSE },
             summary = "Add a license",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicensesResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicensesResource.java
@@ -20,7 +20,7 @@ import java.util.List;
 public interface LicensesResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.LICENSES },
             summary = "Get all licenses information",
@@ -39,8 +39,8 @@ public interface LicensesResource {
     Response getLicenses();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.LICENSES },
             summary = "Set a list of licenses",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerPopResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerPopResource.java
@@ -21,7 +21,7 @@ public interface MailServerPopResource {
 
     @GET
     @Path(BootstrAPI.MAIL_SERVER_POP)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.MAIL_SERVER },
             summary = "Get the default POP mail server",
@@ -44,8 +44,8 @@ public interface MailServerPopResource {
 
     @PUT
     @Path(BootstrAPI.MAIL_SERVER_POP)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.MAIL_SERVER },
             summary = "Set the default POP mail server",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerSmtpResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerSmtpResource.java
@@ -21,7 +21,7 @@ public interface MailServerSmtpResource {
 
     @GET
     @Path(BootstrAPI.MAIL_SERVER_SMTP)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.MAIL_SERVER },
             summary = "Get the default SMTP mail server",
@@ -44,8 +44,8 @@ public interface MailServerSmtpResource {
 
     @PUT
     @Path(BootstrAPI.MAIL_SERVER_SMTP)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.MAIL_SERVER },
             summary = "Set the default SMTP mail server",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PermissionsResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PermissionsResource.java
@@ -16,7 +16,7 @@ public interface PermissionsResource {
 
     @GET
     @Path(BootstrAPI.PERMISSIONS_GLOBAL)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.PERMISSIONS },
             summary = "Get global permissions configuration",
@@ -30,8 +30,8 @@ public interface PermissionsResource {
 
     @PUT
     @Path(BootstrAPI.PERMISSIONS_GLOBAL)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.PERMISSIONS },
             summary = "Set global permissions configuration",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/UserResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/UserResource.java
@@ -20,7 +20,7 @@ import javax.ws.rs.core.Response;
 public interface UserResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.USER },
             summary = "Get a user",
@@ -39,8 +39,8 @@ public interface UserResource {
             @QueryParam("username") final String username);
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.USER },
             summary = "Update an user",
@@ -62,7 +62,7 @@ public interface UserResource {
     @PUT
     @Path(BootstrAPI.USER_PASSWORD)
     @Consumes(MediaType.TEXT_PLAIN)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.USER },
             summary = "Update a user password",

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyReader.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyReader.java
@@ -1,0 +1,53 @@
+package com.deftdevs.bootstrapi.commons.rest.provider;
+
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
+import com.deftdevs.bootstrapi.commons.exception.web.BadRequestException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * Deserializes YAML request bodies into the same models as the JSON
+ * provider, so any endpoint accepting a configuration also accepts it as
+ * YAML ({@code Content-Type: application/yaml}).
+ */
+@Provider
+@Consumes({BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+public class YamlMessageBodyReader implements MessageBodyReader<Object> {
+
+    @Override
+    public boolean isReadable(
+            final Class<?> type,
+            final Type genericType,
+            final Annotation[] annotations,
+            final MediaType mediaType) {
+
+        return true;
+    }
+
+    @Override
+    public Object readFrom(
+            final Class<Object> type,
+            final Type genericType,
+            final Annotation[] annotations,
+            final MediaType mediaType,
+            final MultivaluedMap<String, String> httpHeaders,
+            final InputStream entityStream) throws IOException {
+
+        try {
+            return YamlObjectMapperHolder.YAML_OBJECT_MAPPER.readValue(entityStream,
+                    YamlObjectMapperHolder.YAML_OBJECT_MAPPER.getTypeFactory()
+                            .constructType(genericType != null ? genericType : type));
+        } catch (JsonProcessingException e) {
+            throw new BadRequestException(e);
+        }
+    }
+}

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyWriter.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyWriter.java
@@ -1,0 +1,57 @@
+package com.deftdevs.bootstrapi.commons.rest.provider;
+
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * Serializes response models as YAML when the client asks for it
+ * ({@code Accept: application/yaml}); the default response format
+ * remains JSON.
+ */
+@Provider
+@Produces({BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+public class YamlMessageBodyWriter implements MessageBodyWriter<Object> {
+
+    @Override
+    public boolean isWriteable(
+            final Class<?> type,
+            final Type genericType,
+            final Annotation[] annotations,
+            final MediaType mediaType) {
+
+        return true;
+    }
+
+    @Override
+    public long getSize(
+            final Object object,
+            final Class<?> type,
+            final Type genericType,
+            final Annotation[] annotations,
+            final MediaType mediaType) {
+
+        return -1;
+    }
+
+    @Override
+    public void writeTo(
+            final Object object,
+            final Class<?> type,
+            final Type genericType,
+            final Annotation[] annotations,
+            final MediaType mediaType,
+            final MultivaluedMap<String, Object> httpHeaders,
+            final OutputStream entityStream) throws IOException {
+
+        YamlObjectMapperHolder.YAML_OBJECT_MAPPER.writeValue(entityStream, object);
+    }
+}

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlObjectMapperHolder.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlObjectMapperHolder.java
@@ -1,0 +1,19 @@
+package com.deftdevs.bootstrapi.commons.rest.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * The shared YAML {@link ObjectMapper} of the YAML message body providers.
+ * The models are bound through their Jackson annotations and plain field
+ * names, exactly like the JSON providers bind them, so no further modules
+ * are required (and none must be: provided-scope Jackson modules are not
+ * visible to the plugin bundle at runtime).
+ */
+final class YamlObjectMapperHolder {
+
+    static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private YamlObjectMapperHolder() {
+    }
+}

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyReaderTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyReaderTest.java
@@ -1,0 +1,85 @@
+package com.deftdevs.bootstrapi.commons.rest.provider;
+
+import com.deftdevs.bootstrapi.commons.exception.web.BadRequestException;
+import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
+import com.deftdevs.bootstrapi.commons.model.DirectoryInternalModel;
+import com.deftdevs.bootstrapi.commons.model.MailServerModel;
+import com.deftdevs.bootstrapi.commons.model.SettingsGeneralModel;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class YamlMessageBodyReaderTest {
+
+    private final YamlMessageBodyReader reader = new YamlMessageBodyReader();
+
+    @Test
+    void testIsReadable() {
+        assertTrue(reader.isReadable(SettingsGeneralModel.class, SettingsGeneralModel.class, null, null));
+    }
+
+    @Test
+    void testReadsModelFromYaml() throws Exception {
+        final SettingsGeneralModel model = (SettingsGeneralModel) reader.readFrom(cast(SettingsGeneralModel.class),
+                SettingsGeneralModel.class, null, null, null,
+                stream("title: Example\nbaseUrl: https://example.com\n"));
+
+        assertEquals("Example", model.getTitle());
+        assertEquals("https://example.com", model.getBaseUrl().toString());
+    }
+
+    @Test
+    void testReadsNestedModelFromYaml() throws Exception {
+        final MailServerModel model = (MailServerModel) reader.readFrom(cast(MailServerModel.class),
+                MailServerModel.class, null, null, null,
+                stream("smtp:\n  host: localhost\n  port: 25\n"));
+
+        assertEquals("localhost", model.getSmtp().getHost());
+        assertEquals(25, model.getSmtp().getPort());
+    }
+
+    @Test
+    void testReadsPolymorphicModelFromYaml() throws Exception {
+        final Method method = TypeCarrier.class.getDeclaredMethod("directories");
+        final Type mapType = method.getGenericReturnType();
+
+        @SuppressWarnings("unchecked")
+        final Map<String, AbstractDirectoryModel> directories = (Map<String, AbstractDirectoryModel>)
+                reader.readFrom(cast(Map.class), mapType, null, null, null,
+                        stream("internal:\n  type: internal\n  description: An internal directory\n"));
+
+        assertInstanceOf(DirectoryInternalModel.class, directories.get("internal"));
+        assertEquals("An internal directory", directories.get("internal").getDescription());
+    }
+
+    @Test
+    void testMalformedYamlIsBadRequest() {
+        assertThrows(BadRequestException.class, () -> reader.readFrom(cast(SettingsGeneralModel.class),
+                SettingsGeneralModel.class, null, null, null,
+                stream("title: [unclosed\n")));
+    }
+
+    @SuppressWarnings("unused")
+    private interface TypeCarrier {
+        Map<String, AbstractDirectoryModel> directories();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<Object> cast(final Class<?> type) {
+        return (Class<Object>) type;
+    }
+
+    private static InputStream stream(final String yaml) {
+        return new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyWriterTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyWriterTest.java
@@ -1,0 +1,38 @@
+package com.deftdevs.bootstrapi.commons.rest.provider;
+
+import com.deftdevs.bootstrapi.commons.model.SettingsGeneralModel;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class YamlMessageBodyWriterTest {
+
+    private final YamlMessageBodyWriter writer = new YamlMessageBodyWriter();
+
+    @Test
+    void testIsWriteable() {
+        assertTrue(writer.isWriteable(SettingsGeneralModel.class, SettingsGeneralModel.class, null, null));
+    }
+
+    @Test
+    void testGetSizeIsUnknown() {
+        assertEquals(-1, writer.getSize(null, null, null, null, null));
+    }
+
+    @Test
+    void testWritesModelAsYaml() throws Exception {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        writer.writeTo(SettingsGeneralModel.EXAMPLE_1_MINIMAL, SettingsGeneralModel.class,
+                SettingsGeneralModel.class, null, null, null, outputStream);
+
+        final String yaml = outputStream.toString(StandardCharsets.UTF_8.name());
+        assertTrue(yaml.contains("title: \"" + SettingsGeneralModel.EXAMPLE_1_MINIMAL.getTitle() + "\"")
+                        || yaml.contains("title: " + SettingsGeneralModel.EXAMPLE_1_MINIMAL.getTitle()),
+                "expected the title in the YAML output, got:\n" + yaml);
+    }
+}

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsResourceFuncTest.java
@@ -5,6 +5,7 @@ import com.deftdevs.bootstrapi.commons.model.SettingsGeneralModel;
 import com.deftdevs.bootstrapi.commons.util.FieldNames;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.HttpMethod;
@@ -36,6 +37,18 @@ public abstract class AbstractSettingsResourceFuncTest {
         final JsonNode settingsNode = objectMapper.readTree(settingsResponse.body());
         assertFalse(settingsNode.path(FieldNames.of(SettingsGeneralModel.class)).isMissingNode(),
                 "expected a general settings group, got: " + settingsNode);
+    }
+
+    @Test
+    void testGetSettingsAsYaml() throws Exception {
+        final HttpResponse<String> settingsResponse = HttpRequestHelper.builder(SETTINGS_PATH)
+                .acceptMediaType(BootstrAPI.MEDIA_TYPE_YAML)
+                .request();
+        assertEquals(200, settingsResponse.statusCode());
+
+        final JsonNode settingsNode = new ObjectMapper(new YAMLFactory()).readTree(settingsResponse.body());
+        assertFalse(settingsNode.path(FieldNames.of(SettingsGeneralModel.class)).isMissingNode(),
+                "expected a general settings group in the YAML response, got:\n" + settingsResponse.body());
     }
 
     @Test

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/HttpRequestHelper.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/HttpRequestHelper.java
@@ -1,5 +1,6 @@
 package it.com.deftdevs.bootstrapi.commons.rest;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
@@ -69,7 +70,10 @@ public class HttpRequestHelper {
 
         if (payload == null) {
             bodyPublisher = HttpRequest.BodyPublishers.noBody();
-        } else if (MediaType.TEXT_PLAIN.equals(contentMediaType)) {
+        } else if (MediaType.TEXT_PLAIN.equals(contentMediaType)
+                || BootstrAPI.MEDIA_TYPE_YAML.equals(contentMediaType)
+                || BootstrAPI.MEDIA_TYPE_YAML_LEGACY.equals(contentMediaType)
+                || BootstrAPI.MEDIA_TYPE_YAML_TEXT.equals(contentMediaType)) {
             bodyPublisher = HttpRequest.BodyPublishers.ofString(String.valueOf(payload));
         } else if (MediaType.APPLICATION_JSON.equals(contentMediaType)) {
             final ObjectWriter objectWriter = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceFuncTest.java
@@ -1,8 +1,10 @@
 package it.com.deftdevs.bootstrapi.commons.rest;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.model.SettingsGeneralModel;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.HttpMethod;
@@ -52,6 +54,20 @@ public abstract class _AbstractAllResourceFuncTest {
             generalNode = generalNode.path(segment);
         }
         assertEquals(getExampleSettingsGeneralModel().getTitle(), generalNode.path("title").asText());
+    }
+
+    @Test
+    void testSetAllAcceptsYaml() throws Exception {
+        final String yaml = new ObjectMapper(new YAMLFactory()).writeValueAsString(getExampleAllModel());
+
+        final HttpResponse<String> allResponse = HttpRequestHelper.builder(ALL_PATH)
+                .contentMediaType(BootstrAPI.MEDIA_TYPE_YAML)
+                .request(HttpMethod.PUT, yaml);
+        assertEquals(200, allResponse.statusCode(), allResponse.body());
+
+        final JsonNode allNode = objectMapper.readTree(allResponse.body());
+        assertEquals(200, allNode.path("status").path(getSettingsGeneralStatusKey()).path("status").asInt(),
+                "expected a success entry for the general settings, got: " + allNode.path("status"));
     }
 
     @Test

--- a/confluence/Apis/AllApi.md
+++ b/confluence/Apis/AllApi.md
@@ -31,6 +31,6 @@ Apply a complete configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/ApplicationLinkApi.md
+++ b/confluence/Apis/ApplicationLinkApi.md
@@ -32,8 +32,8 @@ Create an application link
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="deleteApplicationLink"></a>
 # **deleteApplicationLink**
@@ -85,7 +85,7 @@ Get an application link
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateApplicationLink"></a>
 # **updateApplicationLink**
@@ -110,6 +110,6 @@ Update an application link
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/ApplicationLinksApi.md
+++ b/confluence/Apis/ApplicationLinksApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setApplicationLinks"></a>
 # **setApplicationLinks**
@@ -82,6 +82,6 @@ Set a list of application links
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/AuthenticationApi.md
+++ b/confluence/Apis/AuthenticationApi.md
@@ -30,7 +30,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getAuthenticationSso"></a>
 # **getAuthenticationSso**
@@ -52,7 +52,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setAuthenticationIdps"></a>
 # **setAuthenticationIdps**
@@ -76,8 +76,8 @@ Set all authentication identity providers
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setAuthenticationSso"></a>
 # **setAuthenticationSso**
@@ -101,6 +101,6 @@ Set authentication SSO configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/CachesApi.md
+++ b/confluence/Apis/CachesApi.md
@@ -35,7 +35,7 @@ Flushes a cache
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getCache"></a>
 # **getCache**
@@ -60,7 +60,7 @@ Read cache information for a specified cache
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getCaches"></a>
 # **getCaches**
@@ -82,7 +82,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateCache"></a>
 # **updateCache**
@@ -107,6 +107,6 @@ Update an existing cache-size. Only Setting maxObjectCount is supported.
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/DirectoriesApi.md
+++ b/confluence/Apis/DirectoriesApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setDirectories"></a>
 # **setDirectories**
@@ -82,6 +82,6 @@ Set directories mapped by their name.
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/DirectoryApi.md
+++ b/confluence/Apis/DirectoryApi.md
@@ -32,8 +32,8 @@ Create a user directory
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="deleteDirectory"></a>
 # **deleteDirectory**
@@ -83,7 +83,7 @@ Get a user directory
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateDirectory"></a>
 # **updateDirectory**
@@ -108,6 +108,6 @@ Update a user directory
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/LicenseApi.md
+++ b/confluence/Apis/LicenseApi.md
@@ -29,6 +29,6 @@ Add a license
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/LicensesApi.md
+++ b/confluence/Apis/LicensesApi.md
@@ -30,7 +30,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setLicenses"></a>
 # **setLicenses**
@@ -54,6 +54,6 @@ Set a list of licenses
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/MailServerApi.md
+++ b/confluence/Apis/MailServerApi.md
@@ -80,7 +80,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getMailServerSmtp"></a>
 # **getMailServerSmtp**
@@ -102,7 +102,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setMailServerPop"></a>
 # **setMailServerPop**
@@ -126,8 +126,8 @@ Set the default POP mail server
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setMailServerSmtp"></a>
 # **setMailServerSmtp**
@@ -151,6 +151,6 @@ Set the default SMTP mail server
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/PermissionsApi.md
+++ b/confluence/Apis/PermissionsApi.md
@@ -30,7 +30,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setPermissionsGlobal"></a>
 # **setPermissionsGlobal**
@@ -56,6 +56,6 @@ Set global permissions configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/SettingsApi.md
+++ b/confluence/Apis/SettingsApi.md
@@ -40,7 +40,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsBrandingColorScheme"></a>
 # **getSettingsBrandingColorScheme**
@@ -62,7 +62,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsBrandingCustomHtml"></a>
 # **getSettingsBrandingCustomHtml**
@@ -84,7 +84,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsBrandingFavicon"></a>
 # **getSettingsBrandingFavicon**
@@ -150,7 +150,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsSecurity"></a>
 # **getSettingsSecurity**
@@ -172,7 +172,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettings"></a>
 # **setSettings**
@@ -198,8 +198,8 @@ Apply a settings configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsBrandingColorScheme"></a>
 # **setSettingsBrandingColorScheme**
@@ -223,8 +223,8 @@ Set the color scheme
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsBrandingCustomHtml"></a>
 # **setSettingsBrandingCustomHtml**
@@ -248,8 +248,8 @@ Set the custom HTML
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsBrandingFavicon"></a>
 # **setSettingsBrandingFavicon**
@@ -274,7 +274,7 @@ null (empty response body)
 ### HTTP request headers
 
 - **Content-Type**: application/octet-stream
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsBrandingLogo"></a>
 # **setSettingsBrandingLogo**
@@ -299,7 +299,7 @@ null (empty response body)
 ### HTTP request headers
 
 - **Content-Type**: application/octet-stream
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsGeneral"></a>
 # **setSettingsGeneral**
@@ -323,8 +323,8 @@ Set the general settings
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsSecurity"></a>
 # **setSettingsSecurity**
@@ -348,6 +348,6 @@ Set the security settings
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/Apis/UserApi.md
+++ b/confluence/Apis/UserApi.md
@@ -32,7 +32,7 @@ Get a user
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setUser"></a>
 # **setUser**
@@ -57,8 +57,8 @@ Update an user
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setUserPassword"></a>
 # **setUserPassword**
@@ -84,5 +84,5 @@ Update a user password
 ### HTTP request headers
 
 - **Content-Type**: text/plain
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsGeneralResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsGeneralResourceImpl.java
@@ -15,8 +15,8 @@ import javax.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_GENERAL)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsGeneralResourceImpl extends AbstractSettingsGeneralResourceImpl<SettingsGeneralModel, ConfluenceSettingsService> {
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsResourceImpl.java
@@ -23,8 +23,8 @@ import javax.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsResourceImpl extends AbstractSettingsResourceImpl<SettingsModel> {
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsSecurityResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsSecurityResourceImpl.java
@@ -15,8 +15,8 @@ import javax.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + '/' + BootstrAPI.SETTINGS_SECURITY)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsSecurityResourceImpl extends AbstractSettingsSecurityResourceImpl<SettingsSecurityModel, ConfluenceSettingsService> {
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/_AllResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/_AllResourceImpl.java
@@ -22,8 +22,8 @@ import javax.ws.rs.core.Response;
 
 @Path(BootstrAPI._ROOT)
 @Tag(name = BootstrAPI._ALL)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class _AllResourceImpl extends _AbstractAllResourceImpl<_AllModel> {
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/CachesResource.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/CachesResource.java
@@ -16,7 +16,7 @@ import javax.ws.rs.core.Response;
 public interface CachesResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.CACHES},
             summary = "Read all cache information",
@@ -34,7 +34,7 @@ public interface CachesResource {
 
     @GET
     @Path("{name}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.CACHES},
             summary = "Read cache information for a specified cache",
@@ -52,8 +52,8 @@ public interface CachesResource {
 
     @PUT
     @Path("{name}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.CACHES},
             summary = "Update an existing cache-size. Only Setting maxObjectCount is supported.",
@@ -72,8 +72,8 @@ public interface CachesResource {
 
     @POST
     @Path("{name}/" + BootstrAPI.CACHE_FLUSH)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.CACHES},
             summary = "Flushes a cache",

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingCustomHtmlResource.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingCustomHtmlResource.java
@@ -18,7 +18,7 @@ import javax.ws.rs.core.Response;
 public interface SettingsBrandingCustomHtmlResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Get the custom HTML",
@@ -36,8 +36,8 @@ public interface SettingsBrandingCustomHtmlResource {
     Response getSettingsBrandingCustomHtml();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Set the custom HTML",

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingResource.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingResource.java
@@ -21,7 +21,7 @@ public interface SettingsBrandingResource {
 
     @GET
     @Path(BootstrAPI.COLOR_SCHEME)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Get the color scheme",
@@ -40,8 +40,8 @@ public interface SettingsBrandingResource {
 
     @PUT
     @Path(BootstrAPI.COLOR_SCHEME)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Set the color scheme",
@@ -81,7 +81,7 @@ public interface SettingsBrandingResource {
     @PUT
     @Path(BootstrAPI.LOGO)
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Set the logo",
@@ -121,7 +121,7 @@ public interface SettingsBrandingResource {
     @PUT
     @Path(BootstrAPI.FAVICON)
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Set the favicon",

--- a/crowd/Apis/AllApi.md
+++ b/crowd/Apis/AllApi.md
@@ -31,6 +31,6 @@ Apply a complete configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/ApplicationApi.md
+++ b/crowd/Apis/ApplicationApi.md
@@ -32,8 +32,8 @@ Create an application
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="deleteApplication"></a>
 # **deleteApplication**
@@ -83,7 +83,7 @@ Get an application
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateApplication"></a>
 # **updateApplication**
@@ -108,6 +108,6 @@ Update an application
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/ApplicationLinkApi.md
+++ b/crowd/Apis/ApplicationLinkApi.md
@@ -32,8 +32,8 @@ Create an application link
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="deleteApplicationLink"></a>
 # **deleteApplicationLink**
@@ -85,7 +85,7 @@ Get an application link
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateApplicationLink"></a>
 # **updateApplicationLink**
@@ -110,6 +110,6 @@ Update an application link
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/ApplicationLinksApi.md
+++ b/crowd/Apis/ApplicationLinksApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setApplicationLinks"></a>
 # **setApplicationLinks**
@@ -82,6 +82,6 @@ Set a list of application links
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/ApplicationsApi.md
+++ b/crowd/Apis/ApplicationsApi.md
@@ -58,7 +58,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setApplications"></a>
 # **setApplications**
@@ -84,6 +84,6 @@ Set a list of applications
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/DirectoriesApi.md
+++ b/crowd/Apis/DirectoriesApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setDirectories"></a>
 # **setDirectories**
@@ -82,6 +82,6 @@ Set directories mapped by their name.
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/DirectoryApi.md
+++ b/crowd/Apis/DirectoryApi.md
@@ -32,8 +32,8 @@ Create a user directory
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="deleteDirectory"></a>
 # **deleteDirectory**
@@ -83,7 +83,7 @@ Get a user directory
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateDirectory"></a>
 # **updateDirectory**
@@ -108,6 +108,6 @@ Update a user directory
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/GroupApi.md
+++ b/crowd/Apis/GroupApi.md
@@ -32,8 +32,8 @@ Create a group
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getGroup"></a>
 # **getGroup**
@@ -59,7 +59,7 @@ Get a group
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateGroup"></a>
 # **updateGroup**
@@ -85,6 +85,6 @@ Update a group
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/GroupsApi.md
+++ b/crowd/Apis/GroupsApi.md
@@ -30,6 +30,6 @@ Set groups
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/LicenseApi.md
+++ b/crowd/Apis/LicenseApi.md
@@ -29,6 +29,6 @@ Add a license
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/LicensesApi.md
+++ b/crowd/Apis/LicensesApi.md
@@ -30,7 +30,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setLicenses"></a>
 # **setLicenses**
@@ -54,6 +54,6 @@ Set a list of licenses
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/MailServerApi.md
+++ b/crowd/Apis/MailServerApi.md
@@ -53,7 +53,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setMailServerSmtp"></a>
 # **setMailServerSmtp**
@@ -77,6 +77,6 @@ Set the default SMTP mail server
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/MailTemplatesApi.md
+++ b/crowd/Apis/MailTemplatesApi.md
@@ -28,7 +28,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setMailTemplates"></a>
 # **setMailTemplates**
@@ -52,6 +52,6 @@ Set the mail templates
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/SessionConfigApi.md
+++ b/crowd/Apis/SessionConfigApi.md
@@ -28,7 +28,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSessionConfig"></a>
 # **setSessionConfig**
@@ -52,6 +52,6 @@ Set the session config
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/SettingsApi.md
+++ b/crowd/Apis/SettingsApi.md
@@ -33,7 +33,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsBrandingLoginPage"></a>
 # **getSettingsBrandingLoginPage**
@@ -55,7 +55,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsGeneral"></a>
 # **getSettingsGeneral**
@@ -77,7 +77,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettings"></a>
 # **setSettings**
@@ -103,8 +103,8 @@ Apply a settings configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsBrandingLoginPage"></a>
 # **setSettingsBrandingLoginPage**
@@ -128,8 +128,8 @@ Set the login-page settings
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsBrandingLogo"></a>
 # **setSettingsBrandingLogo**
@@ -154,7 +154,7 @@ Set the logo
 ### HTTP request headers
 
 - **Content-Type**: image/*
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsGeneral"></a>
 # **setSettingsGeneral**
@@ -178,6 +178,6 @@ Set the general settings
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/TrustedProxiesApi.md
+++ b/crowd/Apis/TrustedProxiesApi.md
@@ -33,7 +33,7 @@ Add a trusted proxy
 ### HTTP request headers
 
 - **Content-Type**: text/plain
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getTrustedProxies"></a>
 # **getTrustedProxies**
@@ -55,7 +55,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="removeTrustedProxy"></a>
 # **removeTrustedProxy**
@@ -80,7 +80,7 @@ Remove a trusted proxy
 ### HTTP request headers
 
 - **Content-Type**: text/plain
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setTrustedProxies"></a>
 # **setTrustedProxies**
@@ -104,6 +104,6 @@ Set the trusted proxies
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/Apis/UserApi.md
+++ b/crowd/Apis/UserApi.md
@@ -32,7 +32,7 @@ Get a user
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setUser"></a>
 # **setUser**
@@ -57,8 +57,8 @@ Update an user
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setUserPassword"></a>
 # **setUserPassword**
@@ -84,5 +84,5 @@ Update a user password
 ### HTTP request headers
 
 - **Content-Type**: text/plain
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsGeneralResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsGeneralResourceImpl.java
@@ -16,8 +16,8 @@ import javax.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_GENERAL)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsGeneralResourceImpl extends AbstractSettingsGeneralResourceImpl<SettingsGeneralModel, CrowdSettingsGeneralService> {
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsResourceImpl.java
@@ -23,8 +23,8 @@ import javax.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsResourceImpl extends AbstractSettingsResourceImpl<SettingsModel> {
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/_AllResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/_AllResourceImpl.java
@@ -22,8 +22,8 @@ import javax.ws.rs.core.Response;
 
 @Path(BootstrAPI._ROOT)
 @Tag(name = BootstrAPI._ALL)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class _AllResourceImpl extends _AbstractAllResourceImpl<_AllModel> {
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationResource.java
@@ -23,8 +23,8 @@ public interface ApplicationResource {
 
     @GET
     @Path("{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION },
             summary = "Get an application",
@@ -43,8 +43,8 @@ public interface ApplicationResource {
             @PathParam("id") long id);
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION },
             summary = "Create an application",
@@ -64,8 +64,8 @@ public interface ApplicationResource {
 
     @PUT
     @Path("{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATION },
             summary = "Update an application",

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public interface ApplicationsResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATIONS },
             summary = "Get all applications",
@@ -40,8 +40,8 @@ public interface ApplicationsResource {
     Map<String, ApplicationModel> getApplications();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.APPLICATIONS },
             summary = "Set a list of applications",

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupResource.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.Response;
 public interface GroupResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.GROUP },
             summary = "Get a group",
@@ -35,8 +35,8 @@ public interface GroupResource {
             @QueryParam("name") final String groupName);
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.GROUP },
             summary = "Create a group",
@@ -56,8 +56,8 @@ public interface GroupResource {
             final GroupModel groupModel);
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.GROUP },
             summary = "Update a group",

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupsResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupsResource.java
@@ -16,8 +16,8 @@ import java.util.Map;
 public interface GroupsResource {
 
     @PATCH
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.GROUPS },
             summary = "Set groups",

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/MailTemplateResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/MailTemplateResource.java
@@ -19,7 +19,7 @@ public interface MailTemplateResource {
 
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.MAIL_TEMPLATES},
             summary = "Get the mail templates",
@@ -31,8 +31,8 @@ public interface MailTemplateResource {
     Response getMailTemplates();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.MAIL_TEMPLATES},
             summary = "Set the mail templates",

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SessionConfigResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SessionConfigResource.java
@@ -19,7 +19,7 @@ public interface SessionConfigResource {
 
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.SESSION_CONFIG},
             summary = "Get the session config",
@@ -31,8 +31,8 @@ public interface SessionConfigResource {
     Response getSessionConfig();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.SESSION_CONFIG},
             summary = "Set the session config",

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SettingsBrandingResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SettingsBrandingResource.java
@@ -16,7 +16,7 @@ import java.io.InputStream;
 public interface SettingsBrandingResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Path(BootstrAPI.SETTINGS_BRANDING_LOGIN_PAGE)
     @Operation(
             tags = { BootstrAPI.SETTINGS },
@@ -29,8 +29,8 @@ public interface SettingsBrandingResource {
     Response getSettingsBrandingLoginPage();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Path(BootstrAPI.SETTINGS_BRANDING_LOGIN_PAGE)
     @Operation(
             tags = { BootstrAPI.SETTINGS },
@@ -45,7 +45,7 @@ public interface SettingsBrandingResource {
 
     @PUT
     @Consumes(BootstrAPI.MEDIA_TYPE_IMAGE)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Path(BootstrAPI.LOGO)
     @Operation(
             tags = { BootstrAPI.SETTINGS },

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/TrustedProxiesResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/TrustedProxiesResource.java
@@ -18,7 +18,7 @@ public interface TrustedProxiesResource {
 
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.TRUSTED_PROXIES},
             summary = "Get the trusted proxies",
@@ -30,8 +30,8 @@ public interface TrustedProxiesResource {
     Response getTrustedProxies();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.TRUSTED_PROXIES},
             summary = "Set the trusted proxies",
@@ -45,7 +45,7 @@ public interface TrustedProxiesResource {
 
     @POST
     @Consumes(MediaType.TEXT_PLAIN)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @XsrfProtectionExcluded
     @Operation(
             tags = {BootstrAPI.TRUSTED_PROXIES},
@@ -60,7 +60,7 @@ public interface TrustedProxiesResource {
 
     @DELETE
     @Consumes(MediaType.TEXT_PLAIN)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = {BootstrAPI.TRUSTED_PROXIES},
             summary = "Remove a trusted proxy",

--- a/jira/Apis/AllApi.md
+++ b/jira/Apis/AllApi.md
@@ -31,6 +31,6 @@ Apply a complete configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/ApplicationLinkApi.md
+++ b/jira/Apis/ApplicationLinkApi.md
@@ -32,8 +32,8 @@ Create an application link
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="deleteApplicationLink"></a>
 # **deleteApplicationLink**
@@ -85,7 +85,7 @@ Get an application link
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateApplicationLink"></a>
 # **updateApplicationLink**
@@ -110,6 +110,6 @@ Update an application link
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/ApplicationLinksApi.md
+++ b/jira/Apis/ApplicationLinksApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setApplicationLinks"></a>
 # **setApplicationLinks**
@@ -82,6 +82,6 @@ Set a list of application links
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/AuthenticationApi.md
+++ b/jira/Apis/AuthenticationApi.md
@@ -30,7 +30,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getAuthenticationSso"></a>
 # **getAuthenticationSso**
@@ -52,7 +52,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setAuthenticationIdps"></a>
 # **setAuthenticationIdps**
@@ -76,8 +76,8 @@ Set all authentication identity providers
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setAuthenticationSso"></a>
 # **setAuthenticationSso**
@@ -101,6 +101,6 @@ Set authentication SSO configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/DirectoriesApi.md
+++ b/jira/Apis/DirectoriesApi.md
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setDirectories"></a>
 # **setDirectories**
@@ -82,6 +82,6 @@ Set directories mapped by their name.
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/DirectoryApi.md
+++ b/jira/Apis/DirectoryApi.md
@@ -32,8 +32,8 @@ Create a user directory
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="deleteDirectory"></a>
 # **deleteDirectory**
@@ -83,7 +83,7 @@ Get a user directory
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="updateDirectory"></a>
 # **updateDirectory**
@@ -108,6 +108,6 @@ Update a user directory
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/LicenseApi.md
+++ b/jira/Apis/LicenseApi.md
@@ -29,6 +29,6 @@ Add a license
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/LicensesApi.md
+++ b/jira/Apis/LicensesApi.md
@@ -30,7 +30,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setLicenses"></a>
 # **setLicenses**
@@ -54,6 +54,6 @@ Set a list of licenses
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/MailServerApi.md
+++ b/jira/Apis/MailServerApi.md
@@ -80,7 +80,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getMailServerSmtp"></a>
 # **getMailServerSmtp**
@@ -102,7 +102,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setMailServerPop"></a>
 # **setMailServerPop**
@@ -126,8 +126,8 @@ Set the default POP mail server
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setMailServerSmtp"></a>
 # **setMailServerSmtp**
@@ -151,6 +151,6 @@ Set the default SMTP mail server
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/PermissionsApi.md
+++ b/jira/Apis/PermissionsApi.md
@@ -30,7 +30,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setPermissionsGlobal"></a>
 # **setPermissionsGlobal**
@@ -56,6 +56,6 @@ Set global permissions configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/Apis/SettingsApi.md
+++ b/jira/Apis/SettingsApi.md
@@ -34,7 +34,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsBrandingBanner"></a>
 # **getSettingsBrandingBanner**
@@ -56,7 +56,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsGeneral"></a>
 # **getSettingsGeneral**
@@ -78,7 +78,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="getSettingsSecurity"></a>
 # **getSettingsSecurity**
@@ -100,7 +100,7 @@ This endpoint does not need any parameter.
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettings"></a>
 # **setSettings**
@@ -126,8 +126,8 @@ Apply a settings configuration
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsBrandingBanner"></a>
 # **setSettingsBrandingBanner**
@@ -151,8 +151,8 @@ Set the banner
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsGeneral"></a>
 # **setSettingsGeneral**
@@ -176,8 +176,8 @@ Set the general settings
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 
 <a name="setSettingsSecurity"></a>
 # **setSettingsSecurity**
@@ -201,6 +201,6 @@ Set the security settings
 
 ### HTTP request headers
 
-- **Content-Type**: application/json
-- **Accept**: application/json
+- **Content-Type**: application/json, application/yaml, application/x-yaml, text/yaml
+- **Accept**: application/json, application/yaml, application/x-yaml, text/yaml
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsGeneralResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsGeneralResourceImpl.java
@@ -15,8 +15,8 @@ import javax.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_GENERAL)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsGeneralResourceImpl extends AbstractSettingsGeneralResourceImpl<SettingsGeneralModel, JiraSettingsService> {
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsResourceImpl.java
@@ -23,8 +23,8 @@ import javax.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsResourceImpl extends AbstractSettingsResourceImpl<SettingsModel> {
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsSecurityResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsSecurityResourceImpl.java
@@ -15,8 +15,8 @@ import javax.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + '/' + BootstrAPI.SETTINGS_SECURITY)
 @Tag(name = BootstrAPI.SETTINGS)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class SettingsSecurityResourceImpl extends AbstractSettingsSecurityResourceImpl<SettingsSecurityModel, JiraSettingsService> {
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/_AllResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/_AllResourceImpl.java
@@ -22,8 +22,8 @@ import javax.ws.rs.core.Response;
 
 @Path(BootstrAPI._ROOT)
 @Tag(name = BootstrAPI._ALL)
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+@Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
 @SystemAdminOnly
 public class _AllResourceImpl extends _AbstractAllResourceImpl<_AllModel> {
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/api/SettingsBrandingBannerResource.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/api/SettingsBrandingBannerResource.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.Response;
 public interface SettingsBrandingBannerResource {
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Get the banner",
@@ -33,8 +33,8 @@ public interface SettingsBrandingBannerResource {
     Response getSettingsBrandingBanner();
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
+    @Produces({MediaType.APPLICATION_JSON, BootstrAPI.MEDIA_TYPE_YAML, BootstrAPI.MEDIA_TYPE_YAML_LEGACY, BootstrAPI.MEDIA_TYPE_YAML_TEXT})
     @Operation(
             tags = { BootstrAPI.SETTINGS },
             summary = "Set the banner",

--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,11 @@
                             <formats>
                                 <format>XML</format>
                             </formats>
+                            <excludes>
+                                <!-- third-party classes bundled into the plugin jar -->
+                                <exclude>org/yaml/**</exclude>
+                                <exclude>com/fasterxml/jackson/dataformat/**</exclude>
+                            </excludes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
A message body reader and writer backed by jackson-dataformat-yaml translate YAML request and response bodies into the same models as the JSON providers, with JAXB annotations as the secondary source so both formats behave identically. Every endpoint consuming or producing JSON now also handles YAML (application/yaml, application/x-yaml, text/yaml), so a configuration file can be applied directly, without converting it to JSON first:

    curl -X PUT -H "Content-Type: application/yaml" --data-binary @config.yaml .../rest/bootstrapi/1/

Responses default to JSON and are returned as YAML when requested via the Accept header; malformed YAML yields a 400. The dataformat version follows the platform Jackson version (2.17.x, which all products provide at runtime), with the Jackson core artifacts excluded from bundling.

Covered by unit tests for the providers (including polymorphic directory models) and functional tests applying a YAML _all configuration and reading /settings as YAML in all three products. The readme gains a cross-product configuration example based on the direct YAML upload.