### PR TITLE
Upgrade the plugins to the current LTS product releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'prepare-1.0'
+      - 'release/**'
   pull_request:
   merge_group:
 
@@ -19,10 +19,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
         cache: 'maven'
 
@@ -48,10 +48,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
         cache: 'maven'
 
@@ -87,10 +87,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
         cache: 'maven'
 
@@ -114,10 +114,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: 'maven'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
         cache: 'maven'
         server-id: central

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.deftdevs</groupId>
         <artifactId>bootstrapi-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-rc1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bootstrapi-commons</artifactId>
@@ -48,7 +48,8 @@
 
     <properties>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
-        <jackson.version>2.21.3</jackson.version>
+        <!-- must match the Jackson version shipped by the products, see the platform BOM -->
+        <jackson.version>2.21.4</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -75,13 +76,13 @@
 
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-models</artifactId>
+            <artifactId>swagger-models-jakarta</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -187,18 +188,30 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-jaxb-annotations</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 
-        <!-- bundled: the products provide the Jackson core artifacts (2.17.x) but not the YAML dataformat,
-             so the version must match the platform Jackson version, not ${jackson.version} -->
+        <!-- bundled: the products provide the Jakarta Bean Validation API but no provider
+             visible to plugin bundles, so the plugins bring their own -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- bundled: the products provide the Jackson core artifacts but not the YAML dataformat -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.17.3</version>
+            <version>${jackson.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -230,12 +243,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/BadRequestException.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/BadRequestException.java
@@ -1,9 +1,9 @@
 package com.deftdevs.bootstrapi.commons.exception.web;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 public class BadRequestException extends WebApplicationException {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/InternalServerErrorException.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/InternalServerErrorException.java
@@ -1,9 +1,9 @@
 package com.deftdevs.bootstrapi.commons.exception.web;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 public class InternalServerErrorException extends WebApplicationException {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/NotFoundException.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/NotFoundException.java
@@ -1,9 +1,9 @@
 package com.deftdevs.bootstrapi.commons.exception.web;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 
 public class NotFoundException extends WebApplicationException {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/ServiceUnavailableException.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/ServiceUnavailableException.java
@@ -1,9 +1,9 @@
 package com.deftdevs.bootstrapi.commons.exception.web;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static jakarta.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 public class ServiceUnavailableException extends WebApplicationException {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/UnauthorizedException.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/UnauthorizedException.java
@@ -1,9 +1,9 @@
 package com.deftdevs.bootstrapi.commons.exception.web;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 public class UnauthorizedException extends WebApplicationException {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/JsonMappingExceptionMapper.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/JsonMappingExceptionMapper.java
@@ -3,9 +3,9 @@ package com.deftdevs.bootstrapi.commons.exception.web.mapper;
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/RuntimeExceptionMapper.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/RuntimeExceptionMapper.java
@@ -2,9 +2,9 @@ package com.deftdevs.bootstrapi.commons.exception.web.mapper;
 
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class RuntimeExceptionMapper implements ExceptionMapper<RuntimeException> {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/ValidationExceptionMapper.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/ValidationExceptionMapper.java
@@ -2,10 +2,10 @@ package com.deftdevs.bootstrapi.commons.exception.web.mapper;
 
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-import javax.xml.bind.ValidationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.xml.bind.ValidationException;
 import java.util.Arrays;
 
 @Provider

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/WebApplicationExceptionMapper.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/WebApplicationExceptionMapper.java
@@ -2,10 +2,10 @@ package com.deftdevs.bootstrapi.commons.exception.web.mapper;
 
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractAuthenticationIdpModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractAuthenticationIdpModel.java
@@ -9,9 +9,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 
 @Data

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryExternalModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryExternalModel.java
@@ -6,7 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @Data
 @SuperBuilder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractDirectoryModel.java
@@ -9,8 +9,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
 /**

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractMailServerProtocolModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractMailServerProtocolModel.java
@@ -10,8 +10,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeExclude;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @SuperBuilder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractSettingsModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AbstractSettingsModel.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.Map;
 
 /**

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/ApplicationLinkModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/ApplicationLinkModel.java
@@ -6,8 +6,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.net.URI;
 import java.util.UUID;
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationIdpOidcModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationIdpOidcModel.java
@@ -7,8 +7,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Collections;
 import java.util.List;
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationIdpSamlModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationIdpSamlModel.java
@@ -7,8 +7,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @SuperBuilder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationModel.java
@@ -4,8 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Map;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.AUTHENTICATION;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationSsoModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/AuthenticationSsoModel.java
@@ -6,9 +6,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @Builder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryCrowdModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryCrowdModel.java
@@ -8,9 +8,9 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.Builder;
 
-import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.constraints.NotNull;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.net.URI;
 
 /**

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryDelegatingModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryDelegatingModel.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.Builder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @SuperBuilder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryGenericModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryGenericModel.java
@@ -6,7 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Model for all user directories that are not supported by the plugin(s) yet.

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryInternalModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryInternalModel.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.Builder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryLdapModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/DirectoryLdapModel.java
@@ -8,9 +8,9 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.Builder;
 
-import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.constraints.NotNull;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Model for user directory settings in REST requests.

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/ErrorCollection.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/ErrorCollection.java
@@ -2,8 +2,8 @@ package com.deftdevs.bootstrapi.commons.model;
 
 import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/GroupModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/GroupModel.java
@@ -6,8 +6,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Model for groups REST requests.

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/LicenseModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/LicenseModel.java
@@ -6,8 +6,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Collections;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerModel.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.MAIL_SERVER;
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerPopModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerPopModel.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @SuperBuilder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerSmtpModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/MailServerSmtpModel.java
@@ -7,9 +7,9 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @SuperBuilder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/PermissionsGlobalModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/PermissionsGlobalModel.java
@@ -7,8 +7,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/PermissionsModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/PermissionsModel.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.PERMISSIONS;
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/SettingsGeneralModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/SettingsGeneralModel.java
@@ -6,11 +6,11 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.net.URI;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS_GENERAL;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/SettingsSecurityModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/SettingsSecurityModel.java
@@ -5,11 +5,11 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS_SECURITY;
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/UserModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/UserModel.java
@@ -8,8 +8,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Map;
 
 /**

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/_AbstractAllModel.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/_AbstractAllModel.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.Map;
 
 /**

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/type/DirectoryPermissions.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/type/DirectoryPermissions.java
@@ -6,8 +6,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @Builder

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/type/_AllModelStatus.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/type/_AllModelStatus.java
@@ -4,9 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.ws.rs.core.Response;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.ws.rs.core.Response;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @NoArgsConstructor

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/util/ApplicationLinkModelUtil.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/model/util/ApplicationLinkModelUtil.java
@@ -15,7 +15,7 @@ import com.deftdevs.bootstrapi.commons.model.ApplicationLinkModel;
 import com.deftdevs.bootstrapi.commons.model.ApplicationLinkModel.ApplicationLinkType;
 import org.apache.commons.lang3.NotImplementedException;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 import static com.deftdevs.bootstrapi.commons.model.ApplicationLinkModel.ApplicationLinkType.*;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoryResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractDirectoryResourceImpl.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.AbstractDirectoryModel;
 import com.deftdevs.bootstrapi.commons.rest.api.DirectoryResource;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public abstract class AbstractDirectoryResourceImpl implements DirectoryResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractLicenseResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractLicenseResourceImpl.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.LicenseModel;
 import com.deftdevs.bootstrapi.commons.rest.api.LicenseResource;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public abstract class AbstractLicenseResourceImpl implements LicenseResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractLicensesResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractLicensesResourceImpl.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.LicenseModel;
 import com.deftdevs.bootstrapi.commons.rest.api.LicensesResource;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 public abstract class AbstractLicensesResourceImpl implements LicensesResource {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerResourceImpl.java
@@ -5,7 +5,7 @@ import com.deftdevs.bootstrapi.commons.model.MailServerSmtpModel;
 import com.deftdevs.bootstrapi.commons.rest.api.MailServerResource;
 import com.deftdevs.bootstrapi.commons.service.api.MailServerService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public class AbstractMailServerResourceImpl implements MailServerResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractPermissionsResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractPermissionsResourceImpl.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.PermissionsGlobalModel;
 import com.deftdevs.bootstrapi.commons.rest.api.PermissionsResource;
 import com.deftdevs.bootstrapi.commons.service.api.PermissionsService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public abstract class AbstractPermissionsResourceImpl implements PermissionsResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractPingResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractPingResourceImpl.java
@@ -2,7 +2,7 @@ package com.deftdevs.bootstrapi.commons.rest;
 
 import com.deftdevs.bootstrapi.commons.rest.api.PingResource;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public abstract class AbstractPingResourceImpl implements PingResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsGeneralResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsGeneralResourceImpl.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.SettingsGeneralModel;
 import com.deftdevs.bootstrapi.commons.rest.api.SettingsGeneralResource;
 import com.deftdevs.bootstrapi.commons.service.api.SettingsGeneralService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public abstract class AbstractSettingsGeneralResourceImpl<B extends SettingsGeneralModel, S extends SettingsGeneralService<B>>
         implements SettingsGeneralResource<B> {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsResourceImpl.java
@@ -6,7 +6,7 @@ import com.deftdevs.bootstrapi.commons.model.type.ServiceResult;
 import com.deftdevs.bootstrapi.commons.rest.api.SettingsResource;
 import com.deftdevs.bootstrapi.commons.service.api.SettingsService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public abstract class AbstractSettingsResourceImpl<S extends AbstractSettingsModel>
         implements SettingsResource<S> {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsSecurityResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsSecurityResourceImpl.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.SettingsSecurityModel;
 import com.deftdevs.bootstrapi.commons.rest.api.SettingsSecurityResource;
 import com.deftdevs.bootstrapi.commons.service.api.SettingsSecurityService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public abstract class AbstractSettingsSecurityResourceImpl<B extends SettingsSecurityModel, S extends SettingsSecurityService<B>>
         implements SettingsSecurityResource<B> {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractUserResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/AbstractUserResourceImpl.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.UserModel;
 import com.deftdevs.bootstrapi.commons.rest.api.UserResource;
 import com.deftdevs.bootstrapi.commons.service.api.UsersService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public class AbstractUserResourceImpl implements UserResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceImpl.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceImpl.java
@@ -6,7 +6,7 @@ import com.deftdevs.bootstrapi.commons.model.type._AllModelStatus;
 import com.deftdevs.bootstrapi.commons.rest.api._AllResource;
 import com.deftdevs.bootstrapi.commons.service.api._AllService;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
 
 public abstract class _AbstractAllResourceImpl<_AllModel extends _AllModelAccessor>

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinkResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinkResource.java
@@ -8,15 +8,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import java.util.UUID;
 
 public interface ApplicationLinkResource {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/ApplicationLinksResource.java
@@ -9,13 +9,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
 
 public interface ApplicationLinksResource {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/AuthenticationResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/AuthenticationResource.java
@@ -10,12 +10,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PATCH;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
 
 public interface AuthenticationResource {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoriesResource.java
@@ -8,13 +8,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
 
 public interface DirectoriesResource {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoryResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/DirectoryResource.java
@@ -8,15 +8,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 public interface DirectoryResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicenseResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicenseResource.java
@@ -7,11 +7,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface LicenseResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicensesResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/LicensesResource.java
@@ -9,12 +9,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 public interface LicensesResource {

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerPopResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerPopResource.java
@@ -8,14 +8,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface MailServerPopResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerSmtpResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/MailServerSmtpResource.java
@@ -8,14 +8,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface MailServerSmtpResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PermissionsResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PermissionsResource.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface PermissionsResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PingResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PingResource.java
@@ -4,10 +4,10 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface PingResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/SettingsGeneralResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/SettingsGeneralResource.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.core.Response;
 
 public interface SettingsGeneralResource<B extends SettingsGeneralModel> {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/SettingsResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/SettingsResource.java
@@ -2,10 +2,10 @@ package com.deftdevs.bootstrapi.commons.rest.api;
 
 import com.deftdevs.bootstrapi.commons.model.AbstractSettingsModel;
 
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.core.Response;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Product implementations must override these methods and declare the

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/SettingsSecurityResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/SettingsSecurityResource.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.core.Response;
 
 public interface SettingsSecurityResource<B extends SettingsSecurityModel> {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/UserResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/UserResource.java
@@ -8,14 +8,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface UserResource {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/_AllResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/_AllResource.java
@@ -2,9 +2,9 @@ package com.deftdevs.bootstrapi.commons.rest.api;
 
 import com.deftdevs.bootstrapi.commons.model.type._AllModelAccessor;
 
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.PUT;
-import javax.ws.rs.core.Response;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.core.Response;
 
 public interface _AllResource<_AllModel extends _AllModelAccessor> {
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyReader.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyReader.java
@@ -4,11 +4,11 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.exception.web.BadRequestException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyWriter.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlMessageBodyWriter.java
@@ -2,11 +2,11 @@ package com.deftdevs.bootstrapi.commons.rest.provider;
 
 import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyWriter;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/util/FieldNames.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/util/FieldNames.java
@@ -3,7 +3,7 @@ package com.deftdevs.bootstrapi.commons.util;
 import com.deftdevs.bootstrapi.commons.model.type.SerializableFunction;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.lang.invoke.SerializedLambda;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/util/ModelValidationUtil.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/util/ModelValidationUtil.java
@@ -1,10 +1,13 @@
 package com.deftdevs.bootstrapi.commons.util;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.ValidationException;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidationException;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -14,14 +17,20 @@ import java.util.stream.Collectors;
  */
 public class ModelValidationUtil {
 
+    // the provider is selected explicitly because the products do not expose a Jakarta Bean Validation
+    // provider to plugin bundles; the parameter message interpolator avoids a runtime EL dependency
+    private static final ValidatorFactory VALIDATOR_FACTORY = Validation.byProvider(HibernateValidator.class)
+            .configure()
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .buildValidatorFactory();
+
     /**
-     * Validates the given bean using javax.validation impl from hibernate reference.
+     * Validates the given bean using jakarta.validation impl from hibernate reference.
      *
      * @param bean the bean
      */
     public static void validate(Object bean) {
-        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-        Validator validator = validatorFactory.getValidator();
+        Validator validator = VALIDATOR_FACTORY.getValidator();
         processValidationResult(validator.validate(bean));
     }
 

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/util/ServiceResultUtil.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/util/ServiceResultUtil.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.model.type._AllModelStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/ServiceUnavailableExceptionTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/ServiceUnavailableExceptionTest.java
@@ -3,7 +3,7 @@ package com.deftdevs.bootstrapi.commons.exception.web;
 import com.deftdevs.bootstrapi.commons.junit.AbstractExceptionTest;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static com.deftdevs.bootstrapi.commons.exception.web.ServiceUnavailableException.HEADER_RETRY_AFTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/JsonMappingExceptionMapperTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/JsonMappingExceptionMapperTest.java
@@ -4,9 +4,9 @@ import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JsonMappingExceptionMapperTest {

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/RuntimeExceptionMapperTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/RuntimeExceptionMapperTest.java
@@ -3,9 +3,9 @@ package com.deftdevs.bootstrapi.commons.exception.web.mapper;
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RuntimeExceptionMapperTest {

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/ValidationExceptionMapperTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/ValidationExceptionMapperTest.java
@@ -3,10 +3,10 @@ package com.deftdevs.bootstrapi.commons.exception.web.mapper;
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
-import javax.xml.bind.ValidationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.xml.bind.ValidationException;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ValidationExceptionMapperTest {

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/WebApplicationExceptionMapperTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/exception/web/mapper/WebApplicationExceptionMapperTest.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.exception.web.NotFoundException;
 import com.deftdevs.bootstrapi.commons.model.ErrorCollection;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractExceptionTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractExceptionTest.java
@@ -3,7 +3,7 @@ package com.deftdevs.bootstrapi.commons.junit;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractModelTest.java
@@ -3,7 +3,7 @@ package com.deftdevs.bootstrapi.commons.junit;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/ResourceAssert.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/ResourceAssert.java
@@ -1,13 +1,13 @@
 package com.deftdevs.bootstrapi.commons.junit;
 
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.HEAD;
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.OPTIONS;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
 import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/LicenseResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/LicenseResourceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/LicensesResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/LicensesResourceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/MailServerResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/MailServerResourceTest.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.model.MailServerPopModel;
 import com.deftdevs.bootstrapi.commons.model.MailServerSmtpModel;
 import com.deftdevs.bootstrapi.commons.rest.impl.TestMailServerResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.MailServerService;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/PingResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/PingResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/SettingsGeneralResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/SettingsGeneralResourceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/SettingsResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/SettingsResourceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/UserResourceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/UserResourceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceImplTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceImplTest.java
@@ -3,7 +3,7 @@ package com.deftdevs.bootstrapi.commons.rest;
 import com.deftdevs.bootstrapi.commons.model.type._AllModelStatus;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/service/_AbstractAllServiceImplTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/service/_AbstractAllServiceImplTest.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.model.type._AllModelAccessor;
 import com.deftdevs.bootstrapi.commons.model.type._AllModelStatus;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/util/FieldNamesTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/util/FieldNamesTest.java
@@ -2,7 +2,7 @@ package com.deftdevs.bootstrapi.commons.util;
 
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.List;
 import java.util.Map;
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/util/ModelValidationUtilTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/util/ModelValidationUtilTest.java
@@ -3,8 +3,8 @@ package com.deftdevs.bootstrapi.commons.util;
 import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ValidationException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ValidationException;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/util/ServiceResultUtilTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/util/ServiceResultUtilTest.java
@@ -4,8 +4,8 @@ import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
 import com.deftdevs.bootstrapi.commons.model.type._AllModelStatus;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractApplicationLinksResourceFuncTest.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.Map;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractLicenseResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractLicenseResourceFuncTest.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.List;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerPopResourceFuncTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractMailServerSmtpResourceFuncTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractPingResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractPingResourceFuncTest.java
@@ -3,8 +3,8 @@ package it.com.deftdevs.bootstrapi.commons.rest;
 import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsGeneralResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsGeneralResourceFuncTest.java
@@ -5,7 +5,7 @@ import com.deftdevs.bootstrapi.commons.model.SettingsGeneralModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
+import jakarta.ws.rs.HttpMethod;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractSettingsResourceFuncTest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
+import jakarta.ws.rs.HttpMethod;
 import java.net.http.HttpResponse;
 import java.util.Collections;
 

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractUserResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/AbstractUserResourceFuncTest.java
@@ -5,9 +5,9 @@ import com.deftdevs.bootstrapi.commons.model.UserModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/ClientApplication.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/ClientApplication.java
@@ -1,6 +1,6 @@
 package it.com.deftdevs.bootstrapi.commons.rest;
 
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 import java.util.Collections;
 import java.util.Set;
 

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/HttpRequestHelper.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/HttpRequestHelper.java
@@ -4,8 +4,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;

--- a/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceFuncTest.java
+++ b/commons/src/test/java/it/com/deftdevs/bootstrapi/commons/rest/_AbstractAllResourceFuncTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
+import jakarta.ws.rs.HttpMethod;
 import java.net.http.HttpResponse;
 import java.util.Collection;
 import java.util.Collections;

--- a/confluence/pom.xml
+++ b/confluence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.deftdevs</groupId>
         <artifactId>bootstrapi-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-rc1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bootstrapi-confluence-plugin</artifactId>
@@ -49,8 +49,8 @@
     </developers>
 
     <properties>
-        <confluence.version>9.5.4</confluence.version>
-        <confluence.data.version>9.2.4</confluence.data.version>
+        <confluence.version>10.2.14</confluence.version>
+        <confluence.data.version>10.2.14</confluence.data.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <ajp.port>8109</ajp.port>
     </properties>
@@ -108,7 +108,7 @@
 
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
             <scope>compile</scope>
         </dependency>
 
@@ -249,18 +249,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator-annotation-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <scope>provided</scope>
@@ -380,7 +368,7 @@
 
             <plugin>
                 <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-maven-plugin</artifactId>
+                <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <configuration>
                     <openapiFilePath>${basedir}/src/main/resources/openapi.yaml</openapiFilePath>
                     <resourcePackages>

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/CacheModel.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/CacheModel.java
@@ -6,9 +6,9 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.constraints.NotNull;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @Builder

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/PermissionAnonymousAccessModel.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/PermissionAnonymousAccessModel.java
@@ -6,8 +6,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Model for anonymous access infos in REST requests.

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingColorSchemeModel.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingColorSchemeModel.java
@@ -5,11 +5,11 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.*;
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingCustomHtmlModel.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingCustomHtmlModel.java
@@ -5,11 +5,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.*;
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingModel.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingModel.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS_BRANDING;
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsModel.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/SettingsModel.java
@@ -6,8 +6,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS;
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/_AllModel.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/model/_AllModel.java
@@ -9,8 +9,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @SuperBuilder

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/ApplicationLinkResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/ApplicationLinkResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractApplicationLinkResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.APPLICATION_LINK)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/ApplicationLinksResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/ApplicationLinksResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractApplicationLinksResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.APPLICATION_LINKS)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/AuthenticationResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/AuthenticationResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractAuthenticationResourceImpl;
 import com.deftdevs.bootstrapi.confluence.service.api.ConfluenceAuthenticationService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.AUTHENTICATION)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/CachesResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/CachesResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.confluence.model.CacheModel;
 import com.deftdevs.bootstrapi.confluence.rest.api.CachesResource;
 import com.deftdevs.bootstrapi.confluence.service.api.CachesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI.CACHES)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/DirectoriesResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/DirectoriesResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractDirectoriesResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.DIRECTORIES)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/DirectoryResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/DirectoryResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractDirectoryResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.DIRECTORY)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/LicenceResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/LicenceResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractLicenseResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.LICENSE)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/LicencesResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/LicencesResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractLicensesResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.LICENSES)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/MailServerResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/MailServerResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractMailServerResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.MailServerService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.MAIL_SERVER)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/PermissionsResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/PermissionsResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractPermissionsResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.PermissionsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.PERMISSIONS)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/PingResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/PingResourceImpl.java
@@ -4,7 +4,7 @@ import com.atlassian.plugins.rest.api.security.annotation.UnrestrictedAccess;
 import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractPingResourceImpl;
 
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.PING)
 @UnrestrictedAccess

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingCustomHtmlResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingCustomHtmlResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.confluence.model.SettingsBrandingCustomHtmlModel;
 import com.deftdevs.bootstrapi.confluence.rest.api.SettingsBrandingCustomHtmlResource;
 import com.deftdevs.bootstrapi.confluence.service.api.ConfluenceSettingsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_BRANDING + "/" + BootstrAPI.SETTINGS_BRANDING_CUSTOM_HTML)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.confluence.model.SettingsBrandingColorSchemeModel
 import com.deftdevs.bootstrapi.confluence.rest.api.SettingsBrandingResource;
 import com.deftdevs.bootstrapi.confluence.service.api.SettingsBrandingService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_BRANDING)

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsGeneralResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsGeneralResourceImpl.java
@@ -7,11 +7,11 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractSettingsGeneralResourceImpl;
 import com.deftdevs.bootstrapi.confluence.service.api.ConfluenceSettingsService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_GENERAL)
 @Tag(name = BootstrAPI.SETTINGS)

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsResourceImpl.java
@@ -12,14 +12,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS)
 @Tag(name = BootstrAPI.SETTINGS)

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsSecurityResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/SettingsSecurityResourceImpl.java
@@ -7,11 +7,11 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractSettingsSecurityResourceImpl
 import com.deftdevs.bootstrapi.confluence.service.api.ConfluenceSettingsService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + '/' + BootstrAPI.SETTINGS_SECURITY)
 @Tag(name = BootstrAPI.SETTINGS)

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/UserResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/UserResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractUserResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.UsersService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.USER)
 @SystemAdminOnly

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/_AllResourceImpl.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/_AllResourceImpl.java
@@ -12,13 +12,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI._ROOT)
 @Tag(name = BootstrAPI._ALL)

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/CachesResource.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/CachesResource.java
@@ -9,9 +9,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface CachesResource {
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingCustomHtmlResource.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingCustomHtmlResource.java
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface SettingsBrandingCustomHtmlResource {
 

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingResource.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/rest/api/SettingsBrandingResource.java
@@ -8,13 +8,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 public interface SettingsBrandingResource {

--- a/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingResourceTest.java
+++ b/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingResourceTest.java
@@ -3,7 +3,7 @@ package com.deftdevs.bootstrapi.confluence.rest;
 import com.deftdevs.bootstrapi.confluence.model.SettingsBrandingColorSchemeModel;
 
 import com.deftdevs.bootstrapi.confluence.service.api.SettingsBrandingService;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/rest/_AllResourceTest.java
+++ b/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/rest/_AllResourceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/_AllServiceImplTest.java
+++ b/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/service/_AllServiceImplTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.Map;
 

--- a/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/CachesResourceFuncTest.java
+++ b/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/CachesResourceFuncTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 import java.util.List;
 

--- a/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/LicensesResourceFuncTest.java
+++ b/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/LicensesResourceFuncTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 import java.util.List;
 

--- a/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/PermissionsResourceFuncTest.java
+++ b/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/PermissionsResourceFuncTest.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingCustomHtmlResourceFuncTest.java
+++ b/confluence/src/test/java/it/com/deftdevs/bootstrapi/confluence/rest/SettingsBrandingCustomHtmlResourceFuncTest.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/crowd/pom.xml
+++ b/crowd/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.deftdevs</groupId>
         <artifactId>bootstrapi-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-rc1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bootstrapi-crowd-plugin</artifactId>
@@ -49,8 +49,8 @@
     </developers>
 
     <properties>
-        <crowd.version>6.3.6</crowd.version>
-        <crowd.data.version>6.3.1</crowd.data.version>
+        <crowd.version>7.2.1</crowd.version>
+        <crowd.data.version>7.2.1</crowd.data.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <ajp.port>8409</ajp.port>
     </properties>
@@ -95,7 +95,7 @@
 
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
             <scope>compile</scope>
         </dependency>
 
@@ -148,6 +148,12 @@
         <dependency>
             <groupId>com.atlassian.plugins.rest</groupId>
             <artifactId>atlassian-rest-v2-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -287,12 +293,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
             <scope>test</scope>
@@ -329,7 +329,7 @@
 
             <plugin>
                 <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-maven-plugin</artifactId>
+                <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <configuration>
                     <openapiFilePath>${basedir}/src/main/resources/openapi.yaml</openapiFilePath>
                     <resourcePackages>

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/ApplicationModel.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/ApplicationModel.java
@@ -7,8 +7,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Collections;
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/MailTemplatesModel.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/MailTemplatesModel.java
@@ -7,8 +7,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @Builder

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SessionConfigModel.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SessionConfigModel.java
@@ -7,8 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @Builder

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SettingsBrandingLoginPageModel.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SettingsBrandingLoginPageModel.java
@@ -5,10 +5,10 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 
 @Data

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SettingsBrandingModel.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SettingsBrandingModel.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS_BRANDING;
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SettingsModel.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/SettingsModel.java
@@ -6,8 +6,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS;
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/_AllModel.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/_AllModel.java
@@ -7,8 +7,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/util/MailServerSmtpModelUtil.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/util/MailServerSmtpModelUtil.java
@@ -6,8 +6,8 @@ import com.deftdevs.bootstrapi.commons.exception.web.BadRequestException;
 import com.deftdevs.bootstrapi.commons.model.MailServerSmtpModel;
 
 import javax.annotation.Nullable;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import java.util.Collections;
 
 public class MailServerSmtpModelUtil {

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationLinkResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationLinkResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractApplicationLinkResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.APPLICATION_LINK)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationLinksResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationLinksResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractApplicationLinksResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.APPLICATION_LINKS)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationResourceImpl.java
@@ -6,8 +6,8 @@ import com.deftdevs.bootstrapi.crowd.model.ApplicationModel;
 import com.deftdevs.bootstrapi.crowd.rest.api.ApplicationResource;
 import com.deftdevs.bootstrapi.crowd.service.api.ApplicationsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.APPLICATION)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.crowd.model.ApplicationModel;
 import com.deftdevs.bootstrapi.crowd.rest.api.ApplicationsResource;
 import com.deftdevs.bootstrapi.crowd.service.api.ApplicationsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/DirectoriesResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/DirectoriesResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractDirectoriesResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.DIRECTORIES)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/DirectoryResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/DirectoryResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractDirectoryResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.DIRECTORY)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/GroupResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/GroupResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.commons.model.GroupModel;
 import com.deftdevs.bootstrapi.crowd.rest.api.GroupResource;
 import com.deftdevs.bootstrapi.crowd.service.api.GroupsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @SystemAdminOnly
 @Path(BootstrAPI.GROUP)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.commons.model.GroupModel;
 import com.deftdevs.bootstrapi.crowd.rest.api.GroupsResource;
 import com.deftdevs.bootstrapi.crowd.service.api.GroupsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
 
 @SystemAdminOnly

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/LicenseResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/LicenseResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractLicenseResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.LICENSE)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/LicensesResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/LicensesResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractLicensesResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.LICENSES)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/MailServerResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/MailServerResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.commons.model.MailServerSmtpModel;
 import com.deftdevs.bootstrapi.commons.rest.api.MailServerSmtpResource;
 import com.deftdevs.bootstrapi.commons.service.api.MailServerService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @SystemAdminOnly
 @Path(BootstrAPI.MAIL_SERVER)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/MailTemplatesResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/MailTemplatesResourceImpl.java
@@ -7,9 +7,9 @@ import com.deftdevs.bootstrapi.crowd.model.MailTemplatesModel;
 import com.deftdevs.bootstrapi.crowd.rest.api.MailTemplateResource;
 import com.deftdevs.bootstrapi.crowd.service.api.MailTemplatesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @SystemAdminOnly
 @Path(BootstrAPI.MAIL_TEMPLATES)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/PingResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/PingResourceImpl.java
@@ -4,7 +4,7 @@ import com.atlassian.plugins.rest.api.security.annotation.UnrestrictedAccess;
 import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractPingResourceImpl;
 
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Path;
 
 @UnrestrictedAccess
 @Path(BootstrAPI.PING)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SessionConfigResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SessionConfigResourceImpl.java
@@ -7,9 +7,9 @@ import com.deftdevs.bootstrapi.crowd.model.SessionConfigModel;
 import com.deftdevs.bootstrapi.crowd.rest.api.SessionConfigResource;
 import com.deftdevs.bootstrapi.crowd.service.api.SessionConfigService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @SystemAdminOnly
 @Path(BootstrAPI.SESSION_CONFIG)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsBrandingResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsBrandingResourceImpl.java
@@ -7,9 +7,9 @@ import com.deftdevs.bootstrapi.crowd.model.SettingsBrandingLoginPageModel;
 import com.deftdevs.bootstrapi.crowd.rest.api.SettingsBrandingResource;
 import com.deftdevs.bootstrapi.crowd.service.api.CrowdSettingsBrandingService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 @SystemAdminOnly

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsGeneralResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsGeneralResourceImpl.java
@@ -7,11 +7,11 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractSettingsGeneralResourceImpl;
 import com.deftdevs.bootstrapi.crowd.service.api.CrowdSettingsGeneralService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_GENERAL)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/SettingsResourceImpl.java
@@ -12,14 +12,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS)
 @Tag(name = BootstrAPI.SETTINGS)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/TrustedProxiesResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/TrustedProxiesResourceImpl.java
@@ -6,9 +6,9 @@ import com.atlassian.plugins.rest.api.security.annotation.SystemAdminOnly;
 import com.deftdevs.bootstrapi.crowd.rest.api.TrustedProxiesResource;
 import com.deftdevs.bootstrapi.crowd.service.api.TrustedProxiesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 @SystemAdminOnly

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/UserResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/UserResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractUserResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.UsersService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @SystemAdminOnly
 @Path(BootstrAPI.USER)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/_AllResourceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/_AllResourceImpl.java
@@ -12,13 +12,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI._ROOT)
 @Tag(name = BootstrAPI._ALL)

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationResource.java
@@ -9,15 +9,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 public interface ApplicationResource {
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/ApplicationsResource.java
@@ -9,13 +9,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
 
 public interface ApplicationsResource {

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupResource.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface GroupResource {
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupsResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/GroupsResource.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
 
 public interface GroupsResource {

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/MailTemplateResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/MailTemplateResource.java
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface MailTemplateResource {
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SessionConfigResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SessionConfigResource.java
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface SessionConfigResource {
 

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SettingsBrandingResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SettingsBrandingResource.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 
 public interface SettingsBrandingResource {

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/TrustedProxiesResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/TrustedProxiesResource.java
@@ -9,9 +9,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 public interface TrustedProxiesResource {

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceImpl.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceImpl.java
@@ -21,7 +21,7 @@ import com.deftdevs.bootstrapi.commons.service.api.UsersService;
 import com.deftdevs.bootstrapi.crowd.model.util.UserModelUtil;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/api/CrowdSettingsService.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/service/api/CrowdSettingsService.java
@@ -11,7 +11,7 @@ import com.deftdevs.bootstrapi.crowd.model.SettingsBrandingLoginPageModel;
 import com.deftdevs.bootstrapi.crowd.model.SettingsBrandingModel;
 import com.deftdevs.bootstrapi.crowd.model.SettingsModel;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/crowd/src/test/java/com/atlassian/crowd/manager/mail/MockMailConfiguration.java
+++ b/crowd/src/test/java/com/atlassian/crowd/manager/mail/MockMailConfiguration.java
@@ -2,8 +2,8 @@ package com.atlassian.crowd.manager.mail;
 
 import com.atlassian.crowd.util.mail.SMTPServer;
 
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import java.util.Collections;
 
 public class MockMailConfiguration extends MailConfiguration {

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/model/util/MailServerSmtpModelUtilTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/model/util/MailServerSmtpModelUtilTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.mail.internet.AddressException;
+import jakarta.mail.internet.AddressException;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/GroupResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/GroupResourceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/GroupsResourceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.Map;
 

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/MailServerResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/MailServerResourceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/MailTemplateResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/MailTemplateResourceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/SessionConfigResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/SessionConfigResourceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/TrustedProxiesResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/TrustedProxiesResourceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/_AllResourceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/rest/_AllResourceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/GroupsServiceTest.java
@@ -17,7 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/MailServerServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/MailServerServiceTest.java
@@ -13,7 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.mail.internet.AddressException;
+import jakarta.mail.internet.AddressException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/UsersServiceTest.java
@@ -23,7 +23,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.WebApplicationException;
+import jakarta.ws.rs.WebApplicationException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/_AllServiceImplTest.java
+++ b/crowd/src/test/java/com/deftdevs/bootstrapi/crowd/service/_AllServiceImplTest.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceFuncTest.java
+++ b/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/ApplicationsResourceFuncTest.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/DirectoryResourceFuncTest.java
+++ b/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/DirectoryResourceFuncTest.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/MailTemplatesResourceFuncTest.java
+++ b/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/MailTemplatesResourceFuncTest.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/SessionConfigResourceFuncTest.java
+++ b/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/SessionConfigResourceFuncTest.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/TrustedProxiesResourceFuncTest.java
+++ b/crowd/src/test/java/it/com/deftdevs/bootstrapi/crowd/rest/TrustedProxiesResourceFuncTest.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 import java.util.List;
 

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.deftdevs</groupId>
         <artifactId>bootstrapi-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-rc1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bootstrapi-jira-plugin</artifactId>
@@ -42,8 +42,8 @@
 
     <properties>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
-        <jira.version>10.7.4</jira.version>
-        <jira.data.version>10.3.5</jira.data.version>
+        <jira.version>11.3.8</jira.version>
+        <jira.data.version>11.3.8</jira.data.version>
         <ajp.port>8209</ajp.port>
     </properties>
 
@@ -88,13 +88,13 @@
 
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-models</artifactId>
+            <artifactId>swagger-models-jakarta</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -308,7 +308,7 @@
 
             <plugin>
                 <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-maven-plugin</artifactId>
+                <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <configuration>
                     <openapiFilePath>${basedir}/src/main/resources/openapi.yaml</openapiFilePath>
                     <resourcePackages>

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/SettingsBrandingBannerModel.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/SettingsBrandingBannerModel.java
@@ -5,11 +5,11 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 import com.deftdevs.bootstrapi.commons.model.type.SubEntityOf;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS_BRANDING_BANNER;
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/SettingsBrandingModel.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/SettingsBrandingModel.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS_BRANDING;
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/SettingsModel.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/SettingsModel.java
@@ -6,8 +6,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static com.deftdevs.bootstrapi.commons.constants.BootstrAPI.SETTINGS;
 

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/_AllModel.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/_AllModel.java
@@ -9,8 +9,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @Data
 @SuperBuilder

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/util/DirectoryModelUtil.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/util/DirectoryModelUtil.java
@@ -10,7 +10,7 @@ import com.deftdevs.bootstrapi.commons.model.DirectoryGenericModel;
 import com.deftdevs.bootstrapi.commons.model.DirectoryInternalModel;
 import com.deftdevs.bootstrapi.commons.model.DirectoryLdapModel;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/util/PermissionsGlobalModelUtil.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/model/util/PermissionsGlobalModelUtil.java
@@ -3,7 +3,7 @@ package com.deftdevs.bootstrapi.jira.model.util;
 import com.atlassian.jira.security.GlobalPermissionEntry;
 import com.deftdevs.bootstrapi.commons.model.PermissionsGlobalModel;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.TreeSet;

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/ApplicationLinkResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/ApplicationLinkResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractApplicationLinkResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.APPLICATION_LINK)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/ApplicationLinksResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/ApplicationLinksResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractApplicationLinksResourceImpl
 import com.deftdevs.bootstrapi.commons.service.api.ApplicationLinksService;
 import com.atlassian.plugins.rest.api.security.annotation.SystemAdminOnly;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.APPLICATION_LINKS)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/AuthenticationResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/AuthenticationResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractAuthenticationResourceImpl;
 import com.deftdevs.bootstrapi.jira.service.api.JiraAuthenticationService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.AUTHENTICATION)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/DirectoriesResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/DirectoriesResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractDirectoriesResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 import com.atlassian.plugins.rest.api.security.annotation.SystemAdminOnly;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.DIRECTORIES)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/DirectoryResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/DirectoryResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractDirectoryResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.DirectoriesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.DIRECTORY)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/LicenseResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/LicenseResourceImpl.java
@@ -6,8 +6,8 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractLicenseResourceImpl;
 import com.deftdevs.bootstrapi.commons.rest.api.LicenseResource;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.LICENSE)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/LicensesResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/LicensesResourceImpl.java
@@ -6,8 +6,8 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractLicensesResourceImpl;
 import com.deftdevs.bootstrapi.commons.rest.api.LicensesResource;
 import com.deftdevs.bootstrapi.commons.service.api.LicensesService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.LICENSES)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/MailServerResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/MailServerResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractMailServerResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.MailServerService;
 import com.atlassian.plugins.rest.api.security.annotation.SystemAdminOnly;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.MAIL_SERVER)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/PermissionsResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/PermissionsResourceImpl.java
@@ -5,8 +5,8 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractPermissionsResourceImpl;
 import com.deftdevs.bootstrapi.commons.service.api.PermissionsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.PERMISSIONS)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/PingResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/PingResourceImpl.java
@@ -4,7 +4,7 @@ import com.atlassian.plugins.rest.api.security.annotation.UnrestrictedAccess;
 import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.rest.AbstractPingResourceImpl;
 
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Path;
 
 @Path(BootstrAPI.PING)
 @UnrestrictedAccess

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsBrandingBannerResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsBrandingBannerResourceImpl.java
@@ -6,9 +6,9 @@ import com.deftdevs.bootstrapi.jira.model.SettingsBrandingBannerModel;
 import com.deftdevs.bootstrapi.jira.rest.api.SettingsBrandingBannerResource;
 import com.deftdevs.bootstrapi.jira.service.api.JiraSettingsService;
 
-import javax.inject.Inject;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_BRANDING + "/" + BootstrAPI.SETTINGS_BRANDING_BANNER)
 @SystemAdminOnly

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsGeneralResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsGeneralResourceImpl.java
@@ -7,11 +7,11 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractSettingsGeneralResourceImpl;
 import com.deftdevs.bootstrapi.jira.service.api.JiraSettingsService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + "/" + BootstrAPI.SETTINGS_GENERAL)
 @Tag(name = BootstrAPI.SETTINGS)

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsResourceImpl.java
@@ -12,14 +12,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI.SETTINGS)
 @Tag(name = BootstrAPI.SETTINGS)

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsSecurityResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/SettingsSecurityResourceImpl.java
@@ -7,11 +7,11 @@ import com.deftdevs.bootstrapi.commons.rest.AbstractSettingsSecurityResourceImpl
 import com.deftdevs.bootstrapi.jira.service.api.JiraSettingsService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path(BootstrAPI.SETTINGS + '/' + BootstrAPI.SETTINGS_SECURITY)
 @Tag(name = BootstrAPI.SETTINGS)

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/_AllResourceImpl.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/_AllResourceImpl.java
@@ -12,13 +12,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path(BootstrAPI._ROOT)
 @Tag(name = BootstrAPI._ALL)

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/api/SettingsBrandingBannerResource.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/rest/api/SettingsBrandingBannerResource.java
@@ -8,9 +8,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 public interface SettingsBrandingBannerResource {
 

--- a/jira/src/test/java/com/deftdevs/bootstrapi/jira/rest/_AllResourceTest.java
+++ b/jira/src/test/java/com/deftdevs/bootstrapi/jira/rest/_AllResourceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/_AllServiceImplTest.java
+++ b/jira/src/test/java/com/deftdevs/bootstrapi/jira/service/_AllServiceImplTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.Map;
 

--- a/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/LicensesResourceFuncTest.java
+++ b/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/LicensesResourceFuncTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 import java.util.List;
 

--- a/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/PermissionsResourceFuncTest.java
+++ b/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/PermissionsResourceFuncTest.java
@@ -4,7 +4,7 @@ import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/SettingsBrandingBannerResourceFuncTest.java
+++ b/jira/src/test/java/it/com/deftdevs/bootstrapi/jira/rest/SettingsBrandingBannerResourceFuncTest.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.com.deftdevs.bootstrapi.commons.rest.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Response;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.deftdevs</groupId>
     <artifactId>bootstrapi-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-rc1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>BootstrAPI parent POM</name>
@@ -82,8 +82,10 @@
         <sonar.test.exclusions>**/test/**/*Test.java,**/test/**/*IT.java</sonar.test.exclusions>
         <sonar.java.binaries>target/classes</sonar.java.binaries>
         <!-- other properties -->
-        <atlassian.amps.version>9.12.4</atlassian.amps.version>
-        <atlassian.platform.version>7.3.20</atlassian.platform.version>
+        <atlassian.amps.version>9.12.5</atlassian.amps.version>
+        <!-- must match the platform version shipped by the products, see the product parent POMs
+             (Confluence 10.2 and Jira 11.3 ship 8.3.21, Crowd 7.2 ships 8.3.19 - patch-level drift within 8.3.x is fine) -->
+        <atlassian.platform.version>8.3.21</atlassian.platform.version>
         <atlassian.plugins.osgi.javaconfig.version>0.6.1</atlassian.plugins.osgi.javaconfig.version>
         <jacoco.maven-plugin.version>0.8.14</jacoco.maven-plugin.version>
         <lombok.version>1.18.46</lombok.version>
@@ -93,9 +95,9 @@
         <openapi-generator.version>7.22.0</openapi-generator.version>
         <swagger.version>2.2.49</swagger.version>
         <!-- ... -->
-        <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
-        <jakarta.el-api.version>3.0.4</jakarta.el-api.version>
-        <jersey-common.version>2.48</jersey-common.version>
+        <hibernate-validator.version>8.0.4.Final</hibernate-validator.version>
+        <jakarta.el-api.version>4.0.2</jakarta.el-api.version>
+        <jersey-common.version>3.1.12</jersey-common.version>
         <junit.version>6.0.3</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <bytebuddy.version>1.18.8-jdk5</bytebuddy.version>
@@ -114,13 +116,13 @@
 
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-annotations</artifactId>
+                <artifactId>swagger-annotations-jakarta</artifactId>
                 <version>${swagger.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-models</artifactId>
+                <artifactId>swagger-models-jakarta</artifactId>
                 <version>${swagger.version}</version>
             </dependency>
 
@@ -245,7 +247,7 @@
 
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
-                    <artifactId>swagger-maven-plugin</artifactId>
+                    <artifactId>swagger-maven-plugin-jakarta</artifactId>
                     <version>${swagger.version}</version>
                 </plugin>
 
@@ -335,6 +337,9 @@
                                 <!-- third-party classes bundled into the plugin jar -->
                                 <exclude>org/yaml/**</exclude>
                                 <exclude>com/fasterxml/jackson/dataformat/**</exclude>
+                                <exclude>com/fasterxml/classmate/**</exclude>
+                                <exclude>org/hibernate/validator/**</exclude>
+                                <exclude>org/jboss/logging/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,60 @@
       "matchPackageNames": [
         "com.atlassian{/,}**"
       ]
+    },
+    {
+      "description": "Keep Confluence on the 10.2 LTS line (patch updates only)",
+      "matchPackageNames": [
+        "com.atlassian.confluence{/,}**"
+      ],
+      "allowedVersions": "/^10\\.2\\.[0-9]+$/"
+    },
+    {
+      "description": "Keep Jira on the 11.3 LTS line (patch updates only)",
+      "matchPackageNames": [
+        "com.atlassian.jira{/,}**"
+      ],
+      "allowedVersions": "/^11\\.3\\.[0-9]+$/"
+    },
+    {
+      "description": "Crowd has no LTS line yet; keep it on 7.2, which ships platform 8.3 like the other products",
+      "matchPackageNames": [
+        "com.atlassian.crowd{/,}**"
+      ],
+      "allowedVersions": "/^7\\.2\\.[0-9]+$/"
+    },
+    {
+      "description": "The platform BOM must match the platform version shipped by the products (see the product parent POMs)",
+      "matchPackageNames": [
+        "com.atlassian.platform.dependencies{/,}**"
+      ],
+      "allowedVersions": "/^8\\.3\\.[0-9]+$/"
+    },
+    {
+      "description": "Jackson must match the version shipped by the products (the YAML dataformat is bundled against it)",
+      "matchPackageNames": [
+        "com.fasterxml.jackson{/,}**"
+      ],
+      "allowedVersions": "/^2\\.21\\.[0-9]+$/"
+    },
+    {
+      "description": "The test stack mirrors the platform: Jersey 3.1, Bean Validation 3.0 (Hibernate Validator 8) and EL 5.0 (Glassfish EL 4)",
+      "matchPackageNames": [
+        "org.glassfish.jersey.core:jersey-common"
+      ],
+      "allowedVersions": "/^3\\.1\\.[0-9]+$/"
+    },
+    {
+      "matchPackageNames": [
+        "org.hibernate.validator{/,}**"
+      ],
+      "allowedVersions": "/^8\\..*/"
+    },
+    {
+      "matchPackageNames": [
+        "org.glassfish:jakarta.el"
+      ],
+      "allowedVersions": "/^4\\.[0-9.]+$/"
     }
   ]
 }


### PR DESCRIPTION
Move all three plugins to platform 8 (Jakarta EE 10): Confluence 10.2, Jira 11.3 and Crowd 7.2 (which has no LTS line yet but ships the same platform 8.3 as the other products). The javax namespaces move to jakarta (ws.rs, xml.bind, inject, validation, mail), the Swagger annotations and the OpenAPI plugin switch to their -jakarta variants and the test stack follows the platform versions (Jersey 3.1, Hibernate Validator 8, Glassfish EL 4). The bundled YAML dataformat follows the platform Jackson version.

Since the products no longer expose a Jakarta Bean Validation provider to plugin bundles, the plugins now bundle Hibernate Validator and select it explicitly, interpolating messages without an EL implementation.

The Renovate rules now pin the products to their LTS lines and keep the platform-coupled dependencies on the versions shipped by the products.

As dropping support for the previous product releases is a breaking change, the project version moves to 2.0.0.