### PR TITLE
Apply a bootstrapi.yaml from the application home on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ The very same document - with the product's own base URL - configures Jira via `
 
 Every sub-field present in the request is applied independently: the response echoes the resulting configuration and reports each sub-field's outcome in its `status` map, keyed by the request's field paths (e.g. `settings/general`, `mailServer/smtp`), answering with the highest sub-field status code.
 
+## Startup configuration
+
+Instead of (or in addition to) calling the REST API, the plugins can apply a configuration automatically during application startup. Place a `bootstrapi.yaml` file with the same structure as the `_all` request body into the application's shared home directory (or local home directory) and it is applied as soon as the application has started.
+
+The startup configuration is cluster-safe: only one node applies the file at a time, and the hash of the last successfully applied document is recorded in the database, so restarts and additional replicas skip an unchanged file.
+
+A configuration that cannot be read, parsed or fully applied stops the application, so an instance never comes up with a configuration it could not reach - in a rolling deployment this blocks the rollout instead of hiding the failure. Since only successful applies are recorded, the configuration is retried when the instance is started again.
+
 ## Installation
 
 Download the plugin for your product from the [releases](https://github.com/deftdevs/bootstrapi/releases) and upload it in the product's administration under *Manage apps* → *Upload app*. The endpoints require a user with system administrator permissions.

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -125,6 +125,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.atlassian.beehive</groupId>
+            <artifactId>beehive-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.atlassian.sal</groupId>
             <artifactId>sal-api</artifactId>
             <scope>provided</scope>

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlObjectMapperHolder.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/provider/YamlObjectMapperHolder.java
@@ -4,15 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
- * The shared YAML {@link ObjectMapper} of the YAML message body providers.
- * The models are bound through their Jackson annotations and plain field
- * names, exactly like the JSON providers bind them, so no further modules
- * are required (and none must be: provided-scope Jackson modules are not
- * visible to the plugin bundle at runtime).
+ * The shared YAML {@link ObjectMapper} of the YAML message body providers
+ * and the startup configuration import. The models are bound through their
+ * Jackson annotations and plain field names, exactly like the JSON providers
+ * bind them, so no further modules are required (and none must be:
+ * provided-scope Jackson modules are not visible to the plugin bundle at
+ * runtime).
  */
-final class YamlObjectMapperHolder {
+public final class YamlObjectMapperHolder {
 
-    static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+    public static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
 
     private YamlObjectMapperHolder() {
     }

--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/startup/StartupConfigLifecycle.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/startup/StartupConfigLifecycle.java
@@ -1,0 +1,198 @@
+package com.deftdevs.bootstrapi.commons.startup;
+
+import com.atlassian.beehive.ClusterLock;
+import com.atlassian.beehive.ClusterLockService;
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.lifecycle.LifecycleAware;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.deftdevs.bootstrapi.commons.model.type._AllModelAccessor;
+import com.deftdevs.bootstrapi.commons.model.type._AllModelStatus;
+import com.deftdevs.bootstrapi.commons.rest.provider.YamlObjectMapperHolder;
+import com.deftdevs.bootstrapi.commons.service.api._AllService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Applies the configuration from a {@code bootstrapi.yaml} file in the
+ * application home directory when the application has started.
+ * <p>
+ * The file is looked up in the shared home first (the right place for a
+ * cluster) and in the local home as a fallback. The configuration document
+ * has the same structure as the body of the {@code _all} endpoint.
+ * <p>
+ * The apply is cluster-safe: a cluster lock guarantees that only one node
+ * applies at a time, and the SHA-256 hash of the last successfully applied
+ * document is recorded in the (database-backed) plugin settings, so other
+ * replicas and later restarts skip an unchanged file.
+ * <p>
+ * A configuration that cannot be read, parsed or fully applied stops the
+ * application: an instance must not come up with a configuration it could
+ * not reach. Since the hash is only recorded on success, the apply is
+ * retried when the instance is started again.
+ */
+public class StartupConfigLifecycle<_AllModel extends _AllModelAccessor> implements LifecycleAware {
+
+    public static final String FILE_NAME = "bootstrapi.yaml";
+
+    static final String LOCK_NAME = "com.deftdevs.bootstrapi.startup-config";
+    static final String SETTINGS_KEY = "com.deftdevs.bootstrapi.startup-config.sha256";
+
+    private static final Logger log = LoggerFactory.getLogger(StartupConfigLifecycle.class);
+
+    private final Class<_AllModel> allModelClass;
+    private final _AllService<_AllModel> allService;
+    private final ApplicationProperties applicationProperties;
+    private final PluginSettingsFactory pluginSettingsFactory;
+    private final ClusterLockService clusterLockService;
+    private final Runnable stopApplication;
+
+    public StartupConfigLifecycle(
+            final Class<_AllModel> allModelClass,
+            final _AllService<_AllModel> allService,
+            final ApplicationProperties applicationProperties,
+            final PluginSettingsFactory pluginSettingsFactory,
+            final ClusterLockService clusterLockService) {
+
+        this(allModelClass, allService, applicationProperties, pluginSettingsFactory, clusterLockService,
+                () -> System.exit(1));
+    }
+
+    StartupConfigLifecycle(
+            final Class<_AllModel> allModelClass,
+            final _AllService<_AllModel> allService,
+            final ApplicationProperties applicationProperties,
+            final PluginSettingsFactory pluginSettingsFactory,
+            final ClusterLockService clusterLockService,
+            final Runnable stopApplication) {
+
+        this.allModelClass = allModelClass;
+        this.allService = allService;
+        this.applicationProperties = applicationProperties;
+        this.pluginSettingsFactory = pluginSettingsFactory;
+        this.clusterLockService = clusterLockService;
+        this.stopApplication = stopApplication;
+    }
+
+    @Override
+    public void onStart() {
+        boolean applied;
+        try {
+            applied = applyStartupConfig();
+        } catch (RuntimeException e) {
+            log.error("Failed to apply the startup configuration", e);
+            applied = false;
+        }
+
+        if (!applied) {
+            log.error("Stopping the application: an instance must not come up"
+                    + " with a startup configuration it could not apply");
+            stopApplication.run();
+        }
+    }
+
+    boolean applyStartupConfig() {
+        final Path configFile = findConfigFile();
+        if (configFile == null) {
+            log.debug("No {} found in the application home, skipping the startup configuration", FILE_NAME);
+            return true;
+        }
+
+        final byte[] configBytes;
+        try {
+            configBytes = Files.readAllBytes(configFile);
+        } catch (IOException e) {
+            log.error("Failed to read the startup configuration {}", configFile, e);
+            return false;
+        }
+
+        final String configHash = sha256Hex(configBytes);
+        final ClusterLock lock = clusterLockService.getLockForName(LOCK_NAME);
+        lock.lock();
+        try {
+            final PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+            if (configHash.equals(pluginSettings.get(SETTINGS_KEY))) {
+                log.info("The startup configuration {} is unchanged and already applied, skipping", configFile);
+                return true;
+            }
+
+            final _AllModel allModel;
+            try {
+                allModel = YamlObjectMapperHolder.YAML_OBJECT_MAPPER.readValue(configBytes, allModelClass);
+            } catch (IOException e) {
+                log.error("Failed to parse the startup configuration {}", configFile, e);
+                return false;
+            }
+
+            log.info("Applying the startup configuration {}", configFile);
+            final _AllModel result = allService.setAll(allModel);
+            if (!isAppliedSuccessfully(configFile, result.getStatus())) {
+                log.error("The startup configuration {} could not be applied completely;"
+                        + " nothing was recorded, so the apply is retried on the next startup", configFile);
+                return false;
+            }
+
+            log.info("Successfully applied the startup configuration {}", configFile);
+            pluginSettings.put(SETTINGS_KEY, configHash);
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private Path findConfigFile() {
+        final Set<Path> candidates = new LinkedHashSet<>();
+        applicationProperties.getSharedHomeDirectory().ifPresent(home -> candidates.add(home.resolve(FILE_NAME)));
+        applicationProperties.getLocalHomeDirectory().ifPresent(home -> candidates.add(home.resolve(FILE_NAME)));
+        return candidates.stream()
+                .filter(Files::isRegularFile)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean isAppliedSuccessfully(
+            final Path configFile,
+            final Map<String, _AllModelStatus> statusMap) {
+
+        boolean success = true;
+        if (statusMap != null) {
+            for (final Map.Entry<String, _AllModelStatus> entry : statusMap.entrySet()) {
+                final _AllModelStatus status = entry.getValue();
+                if (status.getStatus() >= 400) {
+                    success = false;
+                    log.error("Startup configuration {}: applying '{}' failed with status {}: {} {}",
+                            configFile, entry.getKey(), status.getStatus(), status.getMessage(),
+                            status.getDetails() != null ? status.getDetails() : "");
+                }
+            }
+        }
+        return success;
+    }
+
+    private static String sha256Hex(
+            final byte[] bytes) {
+
+        final MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is guaranteed to be available on every JVM
+            throw new IllegalStateException(e);
+        }
+
+        final StringBuilder hex = new StringBuilder();
+        for (final byte b : digest.digest(bytes)) {
+            hex.append(String.format("%02x", b));
+        }
+        return hex.toString();
+    }
+}

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/startup/MapBackedPluginSettings.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/startup/MapBackedPluginSettings.java
@@ -1,0 +1,38 @@
+package com.deftdevs.bootstrapi.commons.startup;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+
+import java.util.Map;
+
+class MapBackedPluginSettings implements PluginSettings {
+
+    private final Map<String, Object> settings;
+
+    MapBackedPluginSettings(
+            final Map<String, Object> settings) {
+
+        this.settings = settings;
+    }
+
+    @Override
+    public Object get(
+            final String key) {
+
+        return settings.get(key);
+    }
+
+    @Override
+    public Object put(
+            final String key,
+            final Object value) {
+
+        return settings.put(key, value);
+    }
+
+    @Override
+    public Object remove(
+            final String key) {
+
+        return settings.remove(key);
+    }
+}

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/startup/StartupConfigLifecycleTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/startup/StartupConfigLifecycleTest.java
@@ -1,0 +1,215 @@
+package com.deftdevs.bootstrapi.commons.startup;
+
+import com.atlassian.beehive.ClusterLock;
+import com.atlassian.beehive.ClusterLockService;
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.deftdevs.bootstrapi.commons.model.type._AllModelAccessor;
+import com.deftdevs.bootstrapi.commons.model.type._AllModelStatus;
+import com.deftdevs.bootstrapi.commons.service.api._AllService;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StartupConfigLifecycleTest {
+
+    @Mock
+    private _AllService<TestAllModel> allService;
+
+    @Mock
+    private ApplicationProperties applicationProperties;
+
+    @Mock
+    private PluginSettingsFactory pluginSettingsFactory;
+
+    @Mock
+    private ClusterLockService clusterLockService;
+
+    @Mock
+    private ClusterLock clusterLock;
+
+    @TempDir
+    private Path sharedHome;
+
+    @TempDir
+    private Path localHome;
+
+    private final Map<String, Object> settings = new HashMap<>();
+
+    private boolean applicationStopped;
+
+    private StartupConfigLifecycle<TestAllModel> startupConfigLifecycle;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(applicationProperties.getSharedHomeDirectory()).thenReturn(Optional.of(sharedHome));
+        lenient().when(applicationProperties.getLocalHomeDirectory()).thenReturn(Optional.of(localHome));
+        lenient().when(clusterLockService.getLockForName(StartupConfigLifecycle.LOCK_NAME)).thenReturn(clusterLock);
+        lenient().doReturn(new MapBackedPluginSettings(settings)).when(pluginSettingsFactory).createGlobalSettings();
+
+        applicationStopped = false;
+        startupConfigLifecycle = new StartupConfigLifecycle<>(
+                TestAllModel.class, allService, applicationProperties, pluginSettingsFactory, clusterLockService,
+                () -> applicationStopped = true);
+    }
+
+    @Test
+    void testNoConfigFileDoesNothing() {
+        startupConfigLifecycle.onStart();
+
+        verify(allService, never()).setAll(any());
+        assertTrue(settings.isEmpty());
+        assertFalse(applicationStopped);
+    }
+
+    @Test
+    void testAppliesNewConfigAndRecordsIt() throws Exception {
+        writeConfig(sharedHome, "title: Example\n");
+        doReturn(resultWithStatus(_AllModelStatus.success())).when(allService).setAll(any());
+
+        startupConfigLifecycle.onStart();
+
+        final ArgumentCaptor<TestAllModel> captor = ArgumentCaptor.forClass(TestAllModel.class);
+        verify(allService).setAll(captor.capture());
+        assertEquals("Example", captor.getValue().getTitle());
+        assertFalse(settings.isEmpty());
+        assertFalse(applicationStopped);
+        verify(clusterLock).lock();
+        verify(clusterLock).unlock();
+    }
+
+    @Test
+    void testSkipsUnchangedConfig() throws Exception {
+        writeConfig(sharedHome, "title: Example\n");
+        doReturn(resultWithStatus(_AllModelStatus.success())).when(allService).setAll(any());
+        startupConfigLifecycle.onStart();
+        final Object recordedHash = settings.get(StartupConfigLifecycle.SETTINGS_KEY);
+
+        startupConfigLifecycle.onStart();
+
+        // still exactly one apply, and the recorded hash is unchanged
+        verify(allService).setAll(any());
+        assertEquals(recordedHash, settings.get(StartupConfigLifecycle.SETTINGS_KEY));
+    }
+
+    @Test
+    void testReappliesChangedConfig() throws Exception {
+        writeConfig(sharedHome, "title: Example\n");
+        settings.put(StartupConfigLifecycle.SETTINGS_KEY, "0000000000000000");
+        doReturn(resultWithStatus(_AllModelStatus.success())).when(allService).setAll(any());
+
+        startupConfigLifecycle.onStart();
+
+        verify(allService).setAll(any());
+        assertFalse(settings.get(StartupConfigLifecycle.SETTINGS_KEY).equals("0000000000000000"));
+    }
+
+    @Test
+    void testPartiallyFailedConfigIsNotRecordedAndStopsTheApplication() throws Exception {
+        writeConfig(sharedHome, "title: Example\n");
+        doReturn(resultWithStatus(_AllModelStatus.error(400, "Bad request", null))).when(allService).setAll(any());
+
+        startupConfigLifecycle.onStart();
+
+        verify(allService).setAll(any());
+        assertTrue(settings.isEmpty());
+        assertTrue(applicationStopped);
+    }
+
+    @Test
+    void testPrefersSharedHomeOverLocalHome() throws Exception {
+        writeConfig(sharedHome, "title: Shared\n");
+        writeConfig(localHome, "title: Local\n");
+        doReturn(resultWithStatus(_AllModelStatus.success())).when(allService).setAll(any());
+
+        startupConfigLifecycle.onStart();
+
+        final ArgumentCaptor<TestAllModel> captor = ArgumentCaptor.forClass(TestAllModel.class);
+        verify(allService).setAll(captor.capture());
+        assertEquals("Shared", captor.getValue().getTitle());
+    }
+
+    @Test
+    void testFallsBackToLocalHome() throws Exception {
+        writeConfig(localHome, "title: Local\n");
+        doReturn(resultWithStatus(_AllModelStatus.success())).when(allService).setAll(any());
+
+        startupConfigLifecycle.onStart();
+
+        final ArgumentCaptor<TestAllModel> captor = ArgumentCaptor.forClass(TestAllModel.class);
+        verify(allService).setAll(captor.capture());
+        assertEquals("Local", captor.getValue().getTitle());
+    }
+
+    @Test
+    void testInvalidConfigIsNotAppliedAndStopsTheApplication() throws Exception {
+        writeConfig(sharedHome, "title: [unclosed\n");
+
+        startupConfigLifecycle.onStart();
+
+        verify(allService, never()).setAll(any());
+        assertTrue(settings.isEmpty());
+        assertTrue(applicationStopped);
+    }
+
+    @Test
+    void testUnexpectedFailureDoesNotThrowButStopsTheApplication() throws Exception {
+        writeConfig(sharedHome, "title: Example\n");
+        when(clusterLockService.getLockForName(any())).thenThrow(new IllegalStateException("boom"));
+
+        assertDoesNotThrow(() -> startupConfigLifecycle.onStart());
+        assertTrue(applicationStopped);
+    }
+
+    private static void writeConfig(
+            final Path home,
+            final String content) throws Exception {
+
+        Files.write(home.resolve(StartupConfigLifecycle.FILE_NAME), content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static TestAllModel resultWithStatus(
+            final _AllModelStatus status) {
+
+        final TestAllModel result = new TestAllModel();
+        final Map<String, _AllModelStatus> statusMap = new LinkedHashMap<>();
+        statusMap.put("title", status);
+        result.setStatus(statusMap);
+        return result;
+    }
+
+    @Data
+    static class TestAllModel implements _AllModelAccessor {
+
+        private String title;
+
+        private Map<String, _AllModelStatus> status;
+
+    }
+}

--- a/confluence/pom.xml
+++ b/confluence/pom.xml
@@ -226,6 +226,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.atlassian.beehive</groupId>
+            <artifactId>beehive-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.sal</groupId>
+            <artifactId>sal-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/AppConfig.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/AppConfig.java
@@ -2,6 +2,7 @@ package com.deftdevs.bootstrapi.confluence;
 
 import com.deftdevs.bootstrapi.confluence.config.AtlassianConfig;
 import com.deftdevs.bootstrapi.confluence.config.HelperConfig;
+import com.deftdevs.bootstrapi.confluence.config.LifecycleConfig;
 import com.deftdevs.bootstrapi.confluence.config.ServiceConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Import;
 @Import({
         AtlassianConfig.class,
         HelperConfig.class,
+        LifecycleConfig.class,
         ServiceConfig.class,
 })
 public class AppConfig {

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/config/AtlassianConfig.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/config/AtlassianConfig.java
@@ -4,6 +4,7 @@ import com.atlassian.applinks.core.ApplinkStatusService;
 import com.atlassian.applinks.spi.auth.AuthenticationConfigurationManager;
 import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
 import com.atlassian.applinks.spi.util.TypeAccessor;
+import com.atlassian.beehive.ClusterLockService;
 import com.atlassian.cache.CacheManager;
 import com.atlassian.confluence.languages.LocaleManager;
 import com.atlassian.confluence.plugins.lookandfeel.SiteLogoManager;
@@ -22,6 +23,7 @@ import com.atlassian.plugins.authentication.api.config.IdpConfigService;
 import com.atlassian.plugins.authentication.api.config.SsoConfigService;
 import com.atlassian.sal.api.ApplicationProperties;
 import com.atlassian.sal.api.license.LicenseHandler;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.user.UserManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,6 +51,11 @@ public class AtlassianConfig {
     @Bean
     public CacheManager cacheManager() {
         return importOsgiService(CacheManager.class);
+    }
+
+    @Bean
+    public ClusterLockService clusterLockService() {
+        return importOsgiService(ClusterLockService.class);
     }
 
     @Bean
@@ -104,6 +111,11 @@ public class AtlassianConfig {
     @Bean
     public PermissionManager permissionManager() {
         return importOsgiService(PermissionManager.class);
+    }
+
+    @Bean
+    public PluginSettingsFactory pluginSettingsFactory() {
+        return importOsgiService(PluginSettingsFactory.class);
     }
 
     @Bean

--- a/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/config/LifecycleConfig.java
+++ b/confluence/src/main/java/com/deftdevs/bootstrapi/confluence/config/LifecycleConfig.java
@@ -1,0 +1,40 @@
+package com.deftdevs.bootstrapi.confluence.config;
+
+import com.atlassian.sal.api.lifecycle.LifecycleAware;
+import com.deftdevs.bootstrapi.commons.startup.StartupConfigLifecycle;
+import com.deftdevs.bootstrapi.confluence.model._AllModel;
+import org.osgi.framework.ServiceRegistration;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.atlassian.plugins.osgi.javaconfig.ExportOptions.as;
+import static com.atlassian.plugins.osgi.javaconfig.OsgiServices.exportOsgiService;
+
+@Configuration
+public class LifecycleConfig {
+
+    @Autowired
+    private AtlassianConfig atlassianConfig;
+
+    @Autowired
+    private ServiceConfig serviceConfig;
+
+    @Bean
+    public StartupConfigLifecycle<_AllModel> startupConfigLifecycle() {
+        return new StartupConfigLifecycle<>(
+                _AllModel.class,
+                serviceConfig._allService(),
+                atlassianConfig.applicationProperties(),
+                atlassianConfig.pluginSettingsFactory(),
+                atlassianConfig.clusterLockService());
+    }
+
+    // SAL only invokes lifecycle callbacks on components exported as OSGi services
+    @Bean
+    public FactoryBean<ServiceRegistration> startupConfigLifecycleExport() {
+        return exportOsgiService(startupConfigLifecycle(), as(LifecycleAware.class));
+    }
+
+}

--- a/crowd/pom.xml
+++ b/crowd/pom.xml
@@ -205,6 +205,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.atlassian.beehive</groupId>
+            <artifactId>beehive-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.sal</groupId>
+            <artifactId>sal-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/AppConfig.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/AppConfig.java
@@ -2,6 +2,7 @@ package com.deftdevs.bootstrapi.crowd;
 
 import com.deftdevs.bootstrapi.crowd.config.AtlassianConfig;
 import com.deftdevs.bootstrapi.crowd.config.HelperConfig;
+import com.deftdevs.bootstrapi.crowd.config.LifecycleConfig;
 import com.deftdevs.bootstrapi.crowd.config.ServiceConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Import;
 @Import({
         AtlassianConfig.class,
         HelperConfig.class,
+        LifecycleConfig.class,
         ServiceConfig.class,
 })
 public class AppConfig {}

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/config/AtlassianConfig.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/config/AtlassianConfig.java
@@ -4,6 +4,7 @@ import com.atlassian.applinks.core.ApplinkStatusService;
 import com.atlassian.applinks.spi.auth.AuthenticationConfigurationManager;
 import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
 import com.atlassian.applinks.spi.util.TypeAccessor;
+import com.atlassian.beehive.ClusterLockService;
 import com.atlassian.config.bootstrap.AtlassianBootstrapManager;
 import com.atlassian.crowd.embedded.api.CrowdService;
 import com.atlassian.crowd.manager.application.ApplicationManager;
@@ -15,6 +16,8 @@ import com.atlassian.oauth.consumer.ConsumerService;
 import com.atlassian.oauth.consumer.ConsumerTokenStore;
 import com.atlassian.oauth.serviceprovider.ServiceProviderConsumerStore;
 import com.atlassian.oauth.serviceprovider.ServiceProviderTokenStore;
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -26,6 +29,11 @@ public class AtlassianConfig {
     @Bean
     public ApplicationManager applicationManager() {
         return importOsgiService(ApplicationManager.class);
+    }
+
+    @Bean
+    public ApplicationProperties applicationProperties() {
+        return importOsgiService(ApplicationProperties.class);
     }
 
     @Bean
@@ -41,6 +49,11 @@ public class AtlassianConfig {
     @Bean
     public AuthenticationConfigurationManager authenticationConfigurationManager() {
         return importOsgiService(AuthenticationConfigurationManager.class);
+    }
+
+    @Bean
+    public ClusterLockService clusterLockService() {
+        return importOsgiService(ClusterLockService.class);
     }
 
     @Bean
@@ -76,6 +89,11 @@ public class AtlassianConfig {
     @Bean
     public MutatingApplicationLinkService mutatingApplicationLinkService() {
         return importOsgiService(MutatingApplicationLinkService.class);
+    }
+
+    @Bean
+    public PluginSettingsFactory pluginSettingsFactory() {
+        return importOsgiService(PluginSettingsFactory.class);
     }
 
     @Bean

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/config/LifecycleConfig.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/config/LifecycleConfig.java
@@ -1,0 +1,40 @@
+package com.deftdevs.bootstrapi.crowd.config;
+
+import com.atlassian.sal.api.lifecycle.LifecycleAware;
+import com.deftdevs.bootstrapi.commons.startup.StartupConfigLifecycle;
+import com.deftdevs.bootstrapi.crowd.model._AllModel;
+import org.osgi.framework.ServiceRegistration;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.atlassian.plugins.osgi.javaconfig.ExportOptions.as;
+import static com.atlassian.plugins.osgi.javaconfig.OsgiServices.exportOsgiService;
+
+@Configuration
+public class LifecycleConfig {
+
+    @Autowired
+    private AtlassianConfig atlassianConfig;
+
+    @Autowired
+    private ServiceConfig serviceConfig;
+
+    @Bean
+    public StartupConfigLifecycle<_AllModel> startupConfigLifecycle() {
+        return new StartupConfigLifecycle<>(
+                _AllModel.class,
+                serviceConfig._allService(),
+                atlassianConfig.applicationProperties(),
+                atlassianConfig.pluginSettingsFactory(),
+                atlassianConfig.clusterLockService());
+    }
+
+    // SAL only invokes lifecycle callbacks on components exported as OSGi services
+    @Bean
+    public FactoryBean<ServiceRegistration> startupConfigLifecycleExport() {
+        return exportOsgiService(startupConfigLifecycle(), as(LifecycleAware.class));
+    }
+
+}

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -178,6 +178,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.atlassian.beehive</groupId>
+            <artifactId>beehive-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.sal</groupId>
+            <artifactId>sal-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/AppConfig.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/AppConfig.java
@@ -2,6 +2,7 @@ package com.deftdevs.bootstrapi.jira;
 
 import com.deftdevs.bootstrapi.jira.config.AtlassianConfig;
 import com.deftdevs.bootstrapi.jira.config.HelperConfig;
+import com.deftdevs.bootstrapi.jira.config.LifecycleConfig;
 import com.deftdevs.bootstrapi.jira.config.ServiceConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Import;
 @Import({
         AtlassianConfig.class,
         HelperConfig.class,
+        LifecycleConfig.class,
         ServiceConfig.class,
 })
 public class AppConfig {

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/config/AtlassianConfig.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/config/AtlassianConfig.java
@@ -4,6 +4,7 @@ import com.atlassian.applinks.core.ApplinkStatusService;
 import com.atlassian.applinks.spi.auth.AuthenticationConfigurationManager;
 import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
 import com.atlassian.applinks.spi.util.TypeAccessor;
+import com.atlassian.beehive.ClusterLockService;
 import com.atlassian.crowd.embedded.api.CrowdDirectoryService;
 import com.atlassian.jira.config.properties.ApplicationProperties;
 import com.atlassian.jira.license.JiraLicenseManager;
@@ -15,6 +16,7 @@ import com.atlassian.oauth.serviceprovider.ServiceProviderConsumerStore;
 import com.atlassian.oauth.serviceprovider.ServiceProviderTokenStore;
 import com.atlassian.plugins.authentication.api.config.IdpConfigService;
 import com.atlassian.plugins.authentication.api.config.SsoConfigService;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,6 +38,11 @@ public class AtlassianConfig {
     @Bean
     public AuthenticationConfigurationManager authenticationConfigurationManager() {
         return importOsgiService(AuthenticationConfigurationManager.class);
+    }
+
+    @Bean
+    public ClusterLockService clusterLockService() {
+        return importOsgiService(ClusterLockService.class);
     }
 
     @Bean
@@ -76,6 +83,16 @@ public class AtlassianConfig {
     @Bean
     public MutatingApplicationLinkService mutatingApplicationLinkService() {
         return importOsgiService(MutatingApplicationLinkService.class);
+    }
+
+    @Bean
+    public PluginSettingsFactory pluginSettingsFactory() {
+        return importOsgiService(PluginSettingsFactory.class);
+    }
+
+    @Bean
+    public com.atlassian.sal.api.ApplicationProperties salApplicationProperties() {
+        return importOsgiService(com.atlassian.sal.api.ApplicationProperties.class);
     }
 
     @Bean

--- a/jira/src/main/java/com/deftdevs/bootstrapi/jira/config/LifecycleConfig.java
+++ b/jira/src/main/java/com/deftdevs/bootstrapi/jira/config/LifecycleConfig.java
@@ -1,0 +1,40 @@
+package com.deftdevs.bootstrapi.jira.config;
+
+import com.atlassian.sal.api.lifecycle.LifecycleAware;
+import com.deftdevs.bootstrapi.commons.startup.StartupConfigLifecycle;
+import com.deftdevs.bootstrapi.jira.model._AllModel;
+import org.osgi.framework.ServiceRegistration;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.atlassian.plugins.osgi.javaconfig.ExportOptions.as;
+import static com.atlassian.plugins.osgi.javaconfig.OsgiServices.exportOsgiService;
+
+@Configuration
+public class LifecycleConfig {
+
+    @Autowired
+    private AtlassianConfig atlassianConfig;
+
+    @Autowired
+    private ServiceConfig serviceConfig;
+
+    @Bean
+    public StartupConfigLifecycle<_AllModel> startupConfigLifecycle() {
+        return new StartupConfigLifecycle<>(
+                _AllModel.class,
+                serviceConfig._allService(),
+                atlassianConfig.salApplicationProperties(),
+                atlassianConfig.pluginSettingsFactory(),
+                atlassianConfig.clusterLockService());
+    }
+
+    // SAL only invokes lifecycle callbacks on components exported as OSGi services
+    @Bean
+    public FactoryBean<ServiceRegistration> startupConfigLifecycleExport() {
+        return exportOsgiService(startupConfigLifecycle(), as(LifecycleAware.class));
+    }
+
+}


### PR DESCRIPTION
The plugins now register a SAL lifecycle component that looks for a bootstrapi.yaml file in the application's shared home (or local home as a fallback) once the application has started, and applies it through the same service the _all endpoint uses. The document therefore has exactly the same structure as the _all request body.

The apply is safe with multiple replicas: a cluster lock ensures only one node applies at a time, and the SHA-256 hash of the last successfully applied document is recorded in the database-backed plugin settings, so other nodes and later restarts skip an unchanged file.

A configuration that cannot be read, parsed or fully applied stops the application, so an instance never comes up with a configuration it could not reach and a rolling deployment halts instead of hiding the failure. Since only successful applies are recorded, the configuration is retried when the instance is started again.