### PR TITLE
Drop unused dependencies

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -80,12 +80,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-models-jakarta</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- provided Atlassian dependencies -->
 
         <dependency>
@@ -139,18 +133,6 @@
         <!-- other provided dependencies -->
 
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
@@ -171,12 +153,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -255,12 +231,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/confluence/pom.xml
+++ b/confluence/pom.xml
@@ -136,12 +136,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.atlassian.core</groupId>
-            <artifactId>atlassian-core-thumbnail</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-api</artifactId>
             <scope>provided</scope>
@@ -165,6 +159,7 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- not imported directly, but Confluence classes exercised by the unit tests link against it -->
         <dependency>
             <groupId>com.atlassian.http</groupId>
             <artifactId>atlassian-http</artifactId>
@@ -237,12 +232,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <scope>provided</scope>
@@ -303,6 +292,12 @@
             <artifactId>bootstrapi-commons</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/crowd/pom.xml
+++ b/crowd/pom.xml
@@ -134,18 +134,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.atlassian.crowd</groupId>
-            <artifactId>crowd-rest-plugin</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.atlassian.scheduler</groupId>
-            <artifactId>atlassian-scheduler-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.atlassian.plugins.rest</groupId>
             <artifactId>atlassian-rest-v2-api</artifactId>
             <scope>provided</scope>

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -92,23 +92,11 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-models-jakarta</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- provided dependencies -->
 
         <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.atlassian.jira</groupId>
-            <artifactId>jira-rest-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
         <jersey-common.version>3.1.12</jersey-common.version>
         <junit.version>6.0.3</junit.version>
         <mockito.version>5.23.0</mockito.version>
-        <bytebuddy.version>1.18.11-jdk5</bytebuddy.version>
         <!-- central publishing properties -->
         <central.autoPublish>true</central.autoPublish>
         <central.waitUntil>published</central.waitUntil>
@@ -117,12 +116,6 @@
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-annotations-jakarta</artifactId>
-                <version>${swagger.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.swagger.core.v3</groupId>
-                <artifactId>swagger-models-jakarta</artifactId>
                 <version>${swagger.version}</version>
             </dependency>
 
@@ -149,12 +142,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-web</artifactId>
-                <version>3.5.14</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit.version}</version>
@@ -172,18 +159,6 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${bytebuddy.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>${bytebuddy.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
None of these are referenced anywhere: the Byte Buddy pin (it only overrode the version bundled by Mockito, which supports the current JDK again on its own), the Spring Boot web starter, the Swagger models (only the annotations are used), the Jakarta annotation and inject APIs and Spring in commons, the thumbnail library in the Confluence plugin, the Jira REST API in the Jira plugin, and the Crowd REST plugin and scheduler API in the Crowd plugin. The EL implementation is gone from the commons test scope because the model validation interpolates messages without EL since the Hibernate Validator is bundled.

The Spring Boot starter's only effect was providing Jackson to the Confluence functional test compilation, which now declares the test-scoped jackson-databind dependency it actually uses. Confluence also keeps atlassian-http: it is not imported either, but Confluence classes exercised by the unit tests link against it.