### PR TITLE
Generate JaCoCo coverage report in the test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,9 @@
                     </execution>
                     <execution>
                         <id>report</id>
+                        <!-- by default, the report goal only runs in the verify phase,
+                             but the CI unit test job only runs the test phase -->
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>


### PR DESCRIPTION
The jacoco:report execution had no explicit phase binding, so it ran in the verify phase by default and was never executed by 'mvn test', which is all the CI unit test job runs. SonarCloud therefore received no coverage data at all and reported 0.0% coverage on new code, failing the quality gate for any pull request that adds code. Binding the report execution to the test phase makes every test run produce the report without CI having to invoke an extra goal.