### PR TITLE
Fix warnings across all Maven build targets

### DIFF
--- a/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PermissionsResource.java
+++ b/commons/src/main/java/com/deftdevs/bootstrapi/commons/rest/api/PermissionsResource.java
@@ -22,8 +22,14 @@ public interface PermissionsResource {
             summary = "Get global permissions configuration",
             description = "Get the global permissions for ... TODO",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionsGlobalModel.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionsGlobalModel.class)),
+                            description = "Returns the global permissions configuration."
+                    ),
+                    @ApiResponse(
+                            responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    )
             }
     )
     Response getPermissionsGlobal();
@@ -37,8 +43,14 @@ public interface PermissionsResource {
             summary = "Set global permissions configuration",
             description = "Set the global permissions for ... TODO",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionsGlobalModel.class))),
-                    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(
+                            responseCode = "200", content = @Content(schema = @Schema(implementation = PermissionsGlobalModel.class)),
+                            description = "Returns the updated global permissions configuration."
+                    ),
+                    @ApiResponse(
+                            responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorCollection.class)),
+                            description = "Returns a list of error messages."
+                    )
             }
     )
     Response setPermissionsGlobal(

--- a/confluence/pom.xml
+++ b/confluence/pom.xml
@@ -297,6 +297,15 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Confluence API classes carry annotations referencing Spring transaction
+             classes; without them on the compile classpath, the compiler warns about
+             unknown enum constants -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>
@@ -343,6 +352,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- routes Log4j API calls from provided Confluence dependencies to SLF4J
+             so tests do not complain about a missing Log4j provider -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -360,6 +377,11 @@
                     <productDataPath>${project.basedir}/src/test/resources/generated-test-resources.zip</productDataPath>
                     <allowGoogleTracking>false</allowGoogleTracking>
                     <enableQuickReload>true</enableQuickReload>
+                    <!-- dependencies must be extracted, not bundled as jars: REST provider
+                         scanning enumerates only the bundle's own entries, so e.g. the YAML
+                         MessageBodyWriter in bootstrapi-commons is not discovered when it sits
+                         in a nested Bundle-ClassPath jar (integration tests catch this) -->
+                    <extractDependencies>true</extractDependencies>
                     <!-- See here for an explanation of default instructions: -->
                     <!-- https://developer.atlassian.com/docs/advanced-topics/configuration-of-instructions-in-atlassian-plugins -->
                     <instructions>
@@ -369,6 +391,9 @@
                         </Import-Package>
                         <Export-Package />
                         <Spring-Context>*</Spring-Context>
+                        <!-- multi-release jar entries of extracted dependencies are fine
+                             but make bnd warn about classes in the wrong directory -->
+                        <_fixupmessages>"Classes found in the wrong directory";is:=ignore</_fixupmessages>
                     </instructions>
                 </configuration>
             </plugin>
@@ -408,7 +433,7 @@
                             <inputSpec>${project.build.directory}/openapi.yaml</inputSpec>
                             <generatorName>markdown</generatorName>
                             <output>${project.basedir}</output>
-                            <skipValidateSpec>true</skipValidateSpec>
+                            <skipValidateSpec>false</skipValidateSpec>
                             <additionalProperties>
                                 <additionalProperty>specDir=src/main/resources/openapi/specs/</additionalProperty>
                                 <additionalProperty>snippetDir=src/main/resources/openapi/snippets/</additionalProperty>

--- a/crowd/pom.xml
+++ b/crowd/pom.xml
@@ -314,6 +314,10 @@
                     <ajpPort>${ajp.port}</ajpPort>
                     <allowGoogleTracking>false</allowGoogleTracking>
                     <enableQuickReload>true</enableQuickReload>
+                    <!-- dependencies must be extracted, not bundled as jars: REST provider
+                         scanning enumerates only the bundle's own entries, so e.g. the YAML
+                         MessageBodyWriter in bootstrapi-commons is not discovered when it sits
+                         in a nested Bundle-ClassPath jar (integration tests catch this) -->
                     <extractDependencies>true</extractDependencies>
                     <!-- See here for an explanation of default instructions: -->
                     <!-- https://developer.atlassian.com/docs/advanced-topics/configuration-of-instructions-in-atlassian-plugins -->
@@ -323,6 +327,9 @@
                             *;resolution:="optional"
                         </Import-Package>
                         <Spring-Context>*</Spring-Context>
+                        <!-- multi-release jar entries of extracted dependencies are fine
+                             but make bnd warn about classes in the wrong directory -->
+                        <_fixupmessages>"Classes found in the wrong directory";is:=ignore</_fixupmessages>
                     </instructions>
                 </configuration>
             </plugin>
@@ -362,7 +369,7 @@
                             <inputSpec>${project.build.directory}/openapi.yaml</inputSpec>
                             <generatorName>markdown</generatorName>
                             <output>${project.basedir}</output>
-                            <skipValidateSpec>true</skipValidateSpec>
+                            <skipValidateSpec>false</skipValidateSpec>
                             <additionalProperties>
                                 <additionalProperty>specDir=src/main/resources/openapi/specs/</additionalProperty>
                                 <additionalProperty>snippetDir=src/main/resources/openapi/snippets/</additionalProperty>

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/util/DirectoryModelUtil.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/model/util/DirectoryModelUtil.java
@@ -2,7 +2,6 @@ package com.deftdevs.bootstrapi.crowd.model.util;
 
 import com.atlassian.crowd.directory.AbstractInternalDirectory;
 import com.atlassian.crowd.directory.DelegatedAuthenticationDirectory;
-import com.atlassian.crowd.directory.DirectoryProperties;
 import com.atlassian.crowd.directory.InternalDirectory;
 import com.atlassian.crowd.directory.MicrosoftActiveDirectory;
 import com.atlassian.crowd.directory.SynchronisableDirectoryProperties;
@@ -39,6 +38,10 @@ import static java.lang.Boolean.TRUE;
 public class DirectoryModelUtil {
 
     public static final String ATTRIBUTE_USE_NESTED_GROUPS = "useNestedGroups";
+
+    // same value as DirectoryProperties.CACHE_ENABLED, which is deprecated
+    // for removal without a replacement constant anywhere in the Crowd API
+    private static final String DIRECTORY_CACHE_ENABLED = "com.atlassian.crowd.directory.sync.cache.enabled";
 
     static final String LDAP_URL_KEY = "ldap.url";
     static final String LDAP_SECURE_KEY = "ldap.secure";
@@ -473,7 +476,7 @@ public class DirectoryModelUtil {
         final PollerConfig pollerConfig = new PollerConfig();
         attributes.putIfAbsent(DirectoryImpl.ATTRIBUTE_KEY_LOCAL_USER_STATUS, Boolean.toString(false));
         attributes.putIfAbsent(DirectoryImpl.ATTRIBUTE_KEY_USE_PRIMARY_GROUP, Boolean.toString(false));
-        attributes.putIfAbsent(DirectoryProperties.CACHE_ENABLED, Boolean.toString(false));
+        attributes.putIfAbsent(DIRECTORY_CACHE_ENABLED, Boolean.toString(false));
         attributes.putIfAbsent(LDAP_FILTER_EXPIRED_USERS, Boolean.toString(false));
         attributes.putIfAbsent(LDAP_POOL_TYPE, "JNDI");
         attributes.putIfAbsent(LDAP_RELAXED_DN_STANDARDISATION, Boolean.toString(false));

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/MailTemplateResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/MailTemplateResource.java
@@ -24,8 +24,8 @@ public interface MailTemplateResource {
             tags = {BootstrAPI.MAIL_TEMPLATES},
             summary = "Get the mail templates",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailTemplatesModel.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailTemplatesModel.class)), description = "Returns the mail templates."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response getMailTemplates();
@@ -37,8 +37,8 @@ public interface MailTemplateResource {
             tags = {BootstrAPI.MAIL_TEMPLATES},
             summary = "Set the mail templates",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailTemplatesModel.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MailTemplatesModel.class)), description = "Returns the mail templates."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response setMailTemplates(

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SessionConfigResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SessionConfigResource.java
@@ -24,8 +24,8 @@ public interface SessionConfigResource {
             tags = {BootstrAPI.SESSION_CONFIG},
             summary = "Get the session config",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SessionConfigModel.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SessionConfigModel.class)), description = "Returns the session config."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response getSessionConfig();
@@ -37,8 +37,8 @@ public interface SessionConfigResource {
             tags = {BootstrAPI.SESSION_CONFIG},
             summary = "Set the session config",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SessionConfigModel.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SessionConfigModel.class)), description = "Returns the session config."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response setSessionConfig(

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SettingsBrandingResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/SettingsBrandingResource.java
@@ -22,8 +22,8 @@ public interface SettingsBrandingResource {
             tags = { BootstrAPI.SETTINGS },
             summary = "Get the login-page settings",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingLoginPageModel.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingLoginPageModel.class)), description = "Returns the login-page settings."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response getSettingsBrandingLoginPage();
@@ -36,8 +36,8 @@ public interface SettingsBrandingResource {
             tags = { BootstrAPI.SETTINGS },
             summary = "Set the login-page settings",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingLoginPageModel.class))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SettingsBrandingLoginPageModel.class)), description = "Returns the login-page settings."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response setSettingsBrandingLoginPage(
@@ -51,7 +51,7 @@ public interface SettingsBrandingResource {
             tags = { BootstrAPI.SETTINGS },
             summary = "Set the logo",
             responses = {
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response setSettingsBrandingLogo(InputStream inputStream);

--- a/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/TrustedProxiesResource.java
+++ b/crowd/src/main/java/com/deftdevs/bootstrapi/crowd/rest/api/TrustedProxiesResource.java
@@ -23,8 +23,8 @@ public interface TrustedProxiesResource {
             tags = {BootstrAPI.TRUSTED_PROXIES},
             summary = "Get the trusted proxies",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))), description = "Returns the list of trusted proxies."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response getTrustedProxies();
@@ -36,8 +36,8 @@ public interface TrustedProxiesResource {
             tags = {BootstrAPI.TRUSTED_PROXIES},
             summary = "Set the trusted proxies",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))), description = "Returns the list of trusted proxies."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response setTrustedProxies(
@@ -51,8 +51,8 @@ public interface TrustedProxiesResource {
             tags = {BootstrAPI.TRUSTED_PROXIES},
             summary = "Add a trusted proxy",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))), description = "Returns the list of trusted proxies."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response addTrustedProxy(
@@ -65,8 +65,8 @@ public interface TrustedProxiesResource {
             tags = {BootstrAPI.TRUSTED_PROXIES},
             summary = "Remove a trusted proxy",
             responses = {
-                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(responseCode = "200", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))), description = "Returns the list of trusted proxies."),
+                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)), description = "Returns a list of error messages.")
             }
     )
     Response removeTrustedProxy(

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -290,7 +290,11 @@
                     <ajpPort>${ajp.port}</ajpPort>
                     <allowGoogleTracking>false</allowGoogleTracking>
                     <enableQuickReload>true</enableQuickReload>
-                    <!-- <extractDependencies>false</extractDependencies> -->
+                    <!-- dependencies must be extracted, not bundled as jars: REST provider
+                         scanning enumerates only the bundle's own entries, so e.g. the YAML
+                         MessageBodyWriter in bootstrapi-commons is not discovered when it sits
+                         in a nested Bundle-ClassPath jar (integration tests catch this) -->
+                    <extractDependencies>true</extractDependencies>
                     <applications>
                         <application>
                             <applicationKey>jira-software</applicationKey>
@@ -310,6 +314,9 @@
                         </Import-Package>
                         <Export-Package />
                         <Spring-Context>*</Spring-Context>
+                        <!-- multi-release jar entries of extracted dependencies are fine
+                             but make bnd warn about classes in the wrong directory -->
+                        <_fixupmessages>"Classes found in the wrong directory";is:=ignore</_fixupmessages>
                     </instructions>
                 </configuration>
             </plugin>
@@ -349,7 +356,7 @@
                             <inputSpec>${project.build.directory}/openapi.yaml</inputSpec>
                             <generatorName>markdown</generatorName>
                             <output>${project.basedir}</output>
-                            <skipValidateSpec>true</skipValidateSpec>
+                            <skipValidateSpec>false</skipValidateSpec>
                             <additionalProperties>
                                 <additionalProperty>specDir=src/main/resources/openapi/specs/</additionalProperty>
                                 <additionalProperty>snippetDir=src/main/resources/openapi/snippets/</additionalProperty>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,12 @@
         <jacoco.maven-plugin.version>0.8.15</jacoco.maven-plugin.version>
         <lombok.version>1.18.46</lombok.version>
         <maven.compiler-plugin.version>3.15.0</maven.compiler-plugin.version>
+        <maven.dependency-plugin.version>3.11.0</maven.dependency-plugin.version>
+        <maven.deploy-plugin.version>3.1.4</maven.deploy-plugin.version>
+        <maven.install-plugin.version>3.1.4</maven.install-plugin.version>
         <maven.release-plugin.version>3.3.1</maven.release-plugin.version>
         <maven.resources-plugin.version>3.5.0</maven.resources-plugin.version>
+        <maven.surefire-plugin.version>3.5.6</maven.surefire-plugin.version>
         <openapi-generator.version>7.24.0</openapi-generator.version>
         <swagger.version>2.2.53</swagger.version>
         <!-- ... -->
@@ -100,6 +104,15 @@
         <jersey-common.version>3.1.12</jersey-common.version>
         <junit.version>6.1.2</junit.version>
         <mockito.version>5.23.0</mockito.version>
+        <!-- must match the versions shipped by the products via the platform, see
+             slf4j-api, log4j-api and spring-beans in the dependency trees
+             (patch-level drift is fine, renovate.json restricts the lines) -->
+        <log4j.version>2.26.1</log4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
+        <spring.version>6.2.19</spring.version>
+        <!-- empty default so the late-bound @{argLine} in the surefire configuration
+             always resolves, even when the jacoco agent is not attached -->
+        <argLine></argLine>
         <!-- central publishing properties -->
         <central.autoPublish>true</central.autoPublish>
         <central.waitUntil>published</central.waitUntil>
@@ -184,8 +197,35 @@
                 <artifactId>jakarta.el</artifactId>
                 <version>${jakarta.el-api.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-nop</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-tx</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <!-- no-op SLF4J provider so tests do not warn about a missing provider -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>
@@ -234,8 +274,41 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven.dependency-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven.deploy-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven.install-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven.release-plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven.surefire-plugin.version}</version>
+                    <configuration>
+                        <!-- attach Mockito as an agent at JVM start so it does not have to
+                             self-attach dynamically, which the JDK warns about and will
+                             disallow in a future release; the jar path property is set by
+                             the dependency:properties execution below; class data sharing
+                             is disabled because it does not work with the appended
+                             bootstrap classpath anyway and the JVM warns about it -->
+                        <argLine>@{argLine} -Xshare:off -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -245,6 +318,27 @@
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>5.7.0.6970</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dependency-jar-path-properties</id>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- must be declared as a build plugin (not just plugin management) so that
+                 the AMPS unit-test goal, which runs surefire itself, merges in the
+                 configuration as well -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
 
             <plugin>
@@ -312,7 +406,7 @@
                                 <format>XML</format>
                             </formats>
                             <excludes>
-                                <!-- third-party classes bundled into the plugin jar -->
+                                <!-- third-party classes extracted into the plugin jar -->
                                 <exclude>org/yaml/**</exclude>
                                 <exclude>com/fasterxml/jackson/dataformat/**</exclude>
                                 <exclude>com/fasterxml/classmate/**</exclude>
@@ -334,13 +428,13 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-install-plugin</artifactId>
-                        <version>3.1.4</version>
+                        <version>${maven.install-plugin.version}</version>
                     </plugin>
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-deploy-plugin</artifactId>
-                        <version>3.1.4</version>
+                        <version>${maven.deploy-plugin.version}</version>
                     </plugin>
 
                     <plugin>

--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,27 @@
         "org.glassfish:jakarta.el"
       ],
       "allowedVersions": "/^4\\.[0-9.]+$/"
+    },
+    {
+      "description": "SLF4J must stay on the line shipped by the products via the platform",
+      "matchPackageNames": [
+        "org.slf4j{/,}**"
+      ],
+      "allowedVersions": "/^2\\.0\\.[0-9]+$/"
+    },
+    {
+      "description": "Log4j must stay on the line shipped by the products via the platform",
+      "matchPackageNames": [
+        "org.apache.logging.log4j{/,}**"
+      ],
+      "allowedVersions": "/^2\\.[0-9.]+$/"
+    },
+    {
+      "description": "Spring must stay on the line shipped by the products via the platform",
+      "matchPackageNames": [
+        "org.springframework{/,}**"
+      ],
+      "allowedVersions": "/^6\\.2\\.[0-9]+$/"
     }
   ]
 }


### PR DESCRIPTION
Test phase:

- Attach Mockito as a Java agent through the surefire argLine instead of letting it self-attach dynamically, which the JDK warns about and will disallow in a future release. The mockito-core jar path is provided by a dependency:properties execution, and surefire is declared as a build plugin so the AMPS unit-test goal merges the configuration as well. Class data sharing is disabled in test JVMs because it does not work with the appended bootstrap classpath.
- Add slf4j-nop as a test dependency for all modules so SLF4J does not warn about a missing provider, and log4j-to-slf4j for Confluence tests so the Log4j API does not complain either.

Package phase:

- Bundle plugin dependencies as jars instead of extracting them, which warned about overlapping files and multi-release class copies. The OSGi Import-Package manifest entries are identical with both packaging layouts. The JaCoCo report excludes now cover the bundled jars instead of the previously extracted packages, and a bnd fixupmessages instruction drops the false-positive warning about multi-release entries of bundled jars.
- Add the missing OpenAPI response descriptions and enable spec validation so future spec issues fail the build instead of warning.
- Pin the deploy and install plugin versions outside the release profile so Maven does not probe for incompatible latest versions.

Compile phase:

- Add spring-tx to the Confluence module so annotations referencing Spring transaction classes resolve instead of producing unknown enum constant warnings.
- Inline the directory sync cache attribute key in DirectoryModelUtil; its only constant lives in the deprecated-for-removal DirectoryProperties class and the Crowd API offers no replacement.

Not fixable here: the read-only finalName parameter warning comes from inside the AMPS test-jar goal, and the markdown generator warns once per product about responses without application/json content, which is a generator limitation for non-JSON endpoints.