### PR TITLE
Re-enable all skipped unit tests

### DIFF
--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractExceptionTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractExceptionTest.java
@@ -1,6 +1,5 @@
 package com.deftdevs.bootstrapi.commons.junit;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -15,20 +14,17 @@ public abstract class AbstractExceptionTest extends AbstractTest {
     private static final String MESSAGE = "Exception";
 
     @Test
-    @Disabled
     void exceptionClassNameShouldEndWithSuffixException() {
         final String beanClassName = getBaseClass().getSimpleName();
         assertTrue(beanClassName.endsWith(CLASS_SUFFIX), "The model class name should end with suffix " + CLASS_SUFFIX);
     }
 
     @Test
-    @Disabled
     void exceptionClassShouldExtendWebApplicationException() {
         assertTrue(WebApplicationException.class.isAssignableFrom(getBaseClass()), "The exception class should extend WebApplicationException");
     }
 
     @Test
-    @Disabled
     void exceptionConstructorsShouldBehaveEqually() throws Exception {
         final Class<?> baseClass = getBaseClass();
         final WebApplicationException messageException = (WebApplicationException) baseClass.getConstructor(String.class)

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/junit/AbstractModelTest.java
@@ -1,9 +1,10 @@
 package com.deftdevs.bootstrapi.commons.junit;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -12,21 +13,29 @@ public abstract class AbstractModelTest extends AbstractTest {
     private static final String CLASS_SUFFIX = "Model";
 
     @Test
-    @Disabled
     void beanClassNameShouldEndWithSuffixModel() {
         final String beanClassName = getBaseClass().getSimpleName();
         assertTrue(beanClassName.endsWith(CLASS_SUFFIX), "The model class name should end with suffix " + CLASS_SUFFIX);
     }
 
     @Test
-    @Disabled
     void beanClassNameAndXmlRootElementShouldMatch() {
-        final String beanClassName = getBaseClass().getSimpleName();
-        final String beanClassBaseName = beanClassName.substring(0, beanClassName.length() - CLASS_SUFFIX.length());
         final XmlRootElement xmlRootElement = getBaseClass().getAnnotation(XmlRootElement.class);
         assertNotNull(xmlRootElement);
-        assertEquals(beanClassBaseName.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase(), xmlRootElement.name(),
-                "The model class camel-case base name and the xml root element kebab-case base name should match");
+        assertEquals(getExpectedXmlRootElementName(), xmlRootElement.name(),
+                "The xml root element name should match the expected name");
+    }
+
+    /**
+     * The kebab-case version of the model class base name by default. Tests of
+     * models with an intentionally different xml root element name, for example
+     * type discriminators or config keys, override this with the same BootstrAPI
+     * constant the model annotation uses.
+     */
+    protected String getExpectedXmlRootElementName() {
+        final String beanClassName = getBaseClass().getSimpleName();
+        final String beanClassBaseName = beanClassName.substring(0, beanClassName.length() - CLASS_SUFFIX.length());
+        return beanClassBaseName.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase(Locale.ROOT);
     }
 
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoriesModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoriesModelTest.java
@@ -1,9 +1,0 @@
-package com.deftdevs.bootstrapi.commons.model;
-
-import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-class DirectoriesModelTest extends AbstractModelTest {
-}

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryCrowdModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryCrowdModelTest.java
@@ -1,9 +1,15 @@
 package com.deftdevs.bootstrapi.commons.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DirectoryCrowdModelTest extends AbstractModelTest {
+
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.DIRECTORY_CROWD;
+    }
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryDelegatingModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryDelegatingModelTest.java
@@ -1,9 +1,15 @@
 package com.deftdevs.bootstrapi.commons.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DirectoryDelegatingModelTest extends AbstractModelTest {
+
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.DIRECTORY_DELEGATING;
+    }
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryInternalModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryInternalModelTest.java
@@ -1,9 +1,15 @@
 package com.deftdevs.bootstrapi.commons.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DirectoryInternalModelTest extends AbstractModelTest {
+
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.DIRECTORY_INTERNAL;
+    }
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryLdapModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/DirectoryLdapModelTest.java
@@ -1,9 +1,15 @@
 package com.deftdevs.bootstrapi.commons.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DirectoryLdapModelTest extends AbstractModelTest {
+
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.DIRECTORY_LDAP;
+    }
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/MailServerPopModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/MailServerPopModelTest.java
@@ -1,5 +1,6 @@
 package com.deftdevs.bootstrapi.commons.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -7,4 +8,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MailServerPopModelTest extends AbstractModelTest {
 
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.MAIL_SERVER_POP;
+    }
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/MailServerSmtpModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/MailServerSmtpModelTest.java
@@ -1,5 +1,6 @@
 package com.deftdevs.bootstrapi.commons.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -7,4 +8,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MailServerSmtpModelTest extends AbstractModelTest {
 
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.MAIL_SERVER_SMTP;
+    }
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/SettingsGeneralModelTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/model/SettingsGeneralModelTest.java
@@ -1,9 +1,15 @@
 package com.deftdevs.bootstrapi.commons.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class SettingsModelTest extends AbstractModelTest {
+class SettingsGeneralModelTest extends AbstractModelTest {
+
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.SETTINGS_GENERAL;
+    }
 }

--- a/commons/src/test/java/com/deftdevs/bootstrapi/commons/service/DefaultApplicationLinkServiceTest.java
+++ b/commons/src/test/java/com/deftdevs/bootstrapi/commons/service/DefaultApplicationLinkServiceTest.java
@@ -12,7 +12,7 @@ import com.atlassian.applinks.internal.common.exception.NoSuchApplinkException;
 import com.atlassian.applinks.internal.common.status.oauth.OAuthConfig;
 import com.atlassian.applinks.internal.status.error.SimpleApplinkError;
 import com.atlassian.applinks.internal.status.oauth.ApplinkOAuthStatus;
-import com.atlassian.applinks.spi.auth.AuthenticationConfigurationException;
+import com.atlassian.applinks.internal.common.exception.ConsumerInformationUnavailableException;
 import com.atlassian.applinks.spi.link.ApplicationLinkDetails;
 import com.atlassian.applinks.spi.link.MutatingApplicationLinkService;
 import com.atlassian.applinks.spi.util.TypeAccessor;
@@ -24,7 +24,6 @@ import com.deftdevs.bootstrapi.commons.model.util.ApplicationLinkModelUtil;
 import com.deftdevs.bootstrapi.commons.types.DefaultApplicationLink;
 import com.deftdevs.bootstrapi.commons.types.DefaultApplicationType;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -233,16 +232,18 @@ class DefaultApplicationLinkServiceTest {
     }
 
     @Test
-    @Disabled
     void testAddApplicationLinkWithAuthenticatorErrorIgnored() throws Exception {
         ApplicationLink applicationLink = createApplicationLink();
         ApplicationLinkModel applicationLinkModel = createApplicationLinkModel();
+        applicationLinkModel.setIgnoreSetupErrors(true);
 
         doReturn(applicationLink).when(mutatingApplicationLinkService).createApplicationLink(
                 any(ApplicationType.class), any(ApplicationLinkDetails.class));
         doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
-        doThrow(new AuthenticationConfigurationException("")).when(mutatingApplicationLinkService).configureAuthenticationForApplicationLink(any(), any(), any(), any());
+        doThrow(new ConsumerInformationUnavailableException("")).when(applicationLinksAuthConfigHelper).setIncomingOAuthConfig(any(), any());
+        doReturn(OAuthConfig.createDisabledConfig()).when(applicationLinksAuthConfigHelper).getOutgoingOAuthConfig(any());
+        doReturn(OAuthConfig.createDisabledConfig()).when(applicationLinksAuthConfigHelper).getIncomingOAuthConfig(any());
         doReturn(createApplinkStatus(applicationLink, CONFIGURATION_ERROR)).when(applinkStatusService).getApplinkStatus(any());
 
         ApplicationLinkModel applicationLinkResponse = applicationLinkService.addApplicationLink(applicationLinkModel);
@@ -252,8 +253,7 @@ class DefaultApplicationLinkServiceTest {
     }
 
     @Test
-    @Disabled
-    void testAddApplicationLinkWithAuthenticatorErrorNOTIgnored() throws Exception {
+    void testAddApplicationLinkWithAuthenticatorErrorNotIgnored() throws Exception {
         ApplicationLink applicationLink = createApplicationLink();
         ApplicationLinkModel applicationLinkModel = createApplicationLinkModel();
 
@@ -261,9 +261,9 @@ class DefaultApplicationLinkServiceTest {
                 any(ApplicationType.class), any(ApplicationLinkDetails.class));
         doReturn(applicationLink).when(mutatingApplicationLinkService).getPrimaryApplicationLink(any());
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
-        doThrow(new AuthenticationConfigurationException("")).when(mutatingApplicationLinkService).configureAuthenticationForApplicationLink(any(), any(), any(), any());
+        doThrow(new ConsumerInformationUnavailableException("")).when(applicationLinksAuthConfigHelper).setIncomingOAuthConfig(any(), any());
 
-        Exception exception = assertThrows(BadRequestException.class, () -> {
+        assertThrows(BadRequestException.class, () -> {
             applicationLinkService.addApplicationLink(applicationLinkModel);
         });
     }

--- a/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingColorSchemeModelTest.java
+++ b/confluence/src/test/java/com/deftdevs/bootstrapi/confluence/model/SettingsBrandingColorSchemeModelTest.java
@@ -1,9 +1,15 @@
 package com.deftdevs.bootstrapi.confluence.model;
 
+import com.deftdevs.bootstrapi.commons.constants.BootstrAPI;
 import com.deftdevs.bootstrapi.commons.junit.AbstractModelTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SettingsBrandingColorSchemeModelTest extends AbstractModelTest {
+
+    @Override
+    protected String getExpectedXmlRootElementName() {
+        return BootstrAPI.COLOR_SCHEME;
+    }
 }


### PR DESCRIPTION
The convention tests in AbstractModelTest and AbstractExceptionTest had been disabled since the Bean-to-Model rename and every inheriting test class reported skipped tests as warnings. The exception tests pass unchanged. The model xml root element convention test now allows a test class to override the expected name, because several models intentionally use short names that act as type discriminators or config keys (directory types, mail server protocols, general settings, color scheme) and must not be renamed; the overrides reference the same BootstrAPI constants the model annotations use.

Along the way this surfaced two dead spots: DirectoriesModelTest had no corresponding model class anymore and is removed, and the test class in SettingsGeneralModelTest.java was still named SettingsModelTest, so it tested a class that does not exist.

The two disabled application link authenticator tests targeted a configureAuthenticationForApplicationLink API the service no longer uses; they are rewritten against the current implementation, covering that an incoming OAuth setup failure is ignored when ignoreSetupErrors is set and results in a 400 otherwise.